### PR TITLE
refactor(jwt): custom devise strategy combined with access list

### DIFF
--- a/app/assets/javascripts/angular/base/app.coffee
+++ b/app/assets/javascripts/angular/base/app.coffee
@@ -16,6 +16,6 @@ angular.module 'Reckoning', [
   spinnerFunction = (data, headersGetter) ->
     NProgress.start()
     data
-  $httpProvider.defaults.headers.common['Authorization'] = "Bearer \"#{AuthToken}\""
+  $httpProvider.defaults.headers.common['Authorization'] = 'Bearer ' + AuthToken
   $httpProvider.defaults.transformRequest.push(spinnerFunction)
 ]

--- a/app/assets/javascripts/angular/base/controllers/timerModal.coffee
+++ b/app/assets/javascripts/angular/base/controllers/timerModal.coffee
@@ -38,7 +38,6 @@ angular.module 'Reckoning'
       else
         timer.value = 0 unless timer.value
         Timer.create(timer).success (data) ->
-          console.log($uibModalInstance)
           $uibModalInstance.close({data: data, status: 'created'})
 
     $scope.cancel = ->

--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -48,9 +48,6 @@ $(document).on 'click', 'code[data-target]', (ev) ->
   $target = $($element.data('target'))
   $target.val($target.val() + $element.text())
 
-$(document).ajaxSend (event, jqxhr, settings) ->
-  jqxhr.setRequestHeader 'Authorization', "Bearer \"#{AuthToken}\""
-
 document.addEventListener 'keydown', (e) ->
   return true if $('form') is undefined
   if navigator.platform.match("Mac")

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,8 +4,10 @@ require 'json_web_token'
 
 module Api
   class BaseController < ActionController::Base
-    include ActionController::HttpAuthentication::Token
-    before_action :authenticate_user_from_token!
+    include Concerns::Accounts
+
+    protect_from_forgery with: :null_session
+
     before_action :authenticate_user!
 
     respond_to :json
@@ -20,32 +22,5 @@ module Api
       I18n.t(state, scope: "resources.messages.#{action}", resource: I18n.t(:"resources.#{resource}"))
     end
     helper_method :resource_message
-
-    private def authenticate_user_from_token!
-      auth_params, _options = token_and_options(request)
-      auth_token = JsonWebToken.decode(auth_params)
-      if auth_token && auth_token[:user_id]
-        user = User.find(auth_token[:user_id])
-        token = AuthToken.find_by(user_id: auth_token[:user_id], token: auth_params, scope: [:api, :system])
-      end
-
-      if user && token && Devise.secure_compare(token.token, auth_params)
-        sign_in user, store: false
-      else
-        render json: { code: "unauthorized", message: I18n.t("devise.failure.unauthenticated") }, status: :unauthorized
-        return
-      end
-    end
-
-    private def current_account
-      @current_account ||= begin
-        if current_user.present?
-          current_user.account
-        elsif request.subdomain.present? && request.subdomain != "www" && request.subdomain != "api"
-          Account.where(subdomain: request.subdomain).first
-        end
-      end
-    end
-    helper_method :current_account
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 # frozen_string_literal: true
 class ApplicationController < ActionController::Base
+  include Concerns::Accounts
+
   protect_from_forgery prepend: true
   check_authorization unless: :unauthorized_controllers
 
@@ -11,17 +13,6 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!, :set_default_nav
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_user_cookie, if: :user_signed_in?
-
-  private def current_account
-    @current_account ||= begin
-      if current_user.present?
-        current_user.account
-      elsif request.subdomain.present? && request.subdomain != "www" && request.subdomain != "api"
-        Account.where(subdomain: request.subdomain).first
-      end
-    end
-  end
-  helper_method :current_account
 
   private def unauthorized_controllers
     devise_controller?

--- a/app/controllers/concerns/accounts.rb
+++ b/app/controllers/concerns/accounts.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module Concerns
+  module Accounts
+    extend ActiveSupport::Concern
+
+    included do
+      helper_method :current_account
+    end
+
+    def current_account
+      @current_account ||= begin
+        if current_user.present?
+          current_user.account
+        elsif request.subdomain.present? && request.subdomain != "www" && request.subdomain != "api"
+          Account.where(subdomain: request.subdomain).first
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
     @auth_token ||= begin
       if user_signed_in?
         JsonWebToken.encode(
-          exp: Time.zone.now.to_i + (1 * 1800),
+          exp: Time.zone.now.to_i + Rails.application.secrets[:jwt_expiration],
           user_id: current_user.id
         )
       else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,8 +10,11 @@ module ApplicationHelper
 
   def auth_token
     @auth_token ||= begin
-      if defined?(current_user) && user_signed_in?
-        AuthToken.system.not_expired.find_or_create_by(user_id: current_user.id).token
+      if user_signed_in?
+        JsonWebToken.encode(
+          exp: Time.zone.now.to_i + (1 * 1800),
+          user_id: current_user.id
+        )
       else
         ""
       end

--- a/app/views/layouts/_js_defaults.slim
+++ b/app/views/layouts/_js_defaults.slim
@@ -1,13 +1,13 @@
 javascript:
-  I18n.defaultLocale = "#{I18n.default_locale}";
-  I18n.locale = "#{I18n.locale}";
-  AuthToken = "#{auth_token}";
-  StripeKey = "#{Rails.application.secrets[:stripe_public_key]}";
-  GoogleApiKey = "#{Rails.application.secrets[:google_api_key]}"
-  PDFJSWorkerPath = "#{asset_path('pdfjs-dist/build/pdf.worker.js')}"
+  I18n.defaultLocale = '#{I18n.default_locale}';
+  I18n.locale = '#{I18n.locale}';
+  AuthToken = '#{auth_token}';
+  StripeKey = '#{Rails.application.secrets[:stripe_public_key]}';
+  GoogleApiKey = '#{Rails.application.secrets[:google_api_key]}'
+  PDFJSWorkerPath = '#{asset_path("pdfjs-dist/build/pdf.worker.js")}'
 
   ApiBasePath = "#{(api_domain if defined?(api_domain))}"
   ApiHeaders = new Headers({
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer "#{auth_token}"'
+    'Authorization': 'Bearer #{auth_token}'
   });

--- a/config/initializers/core_extensions/devise/json_failure_app.rb
+++ b/config/initializers/core_extensions/devise/json_failure_app.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+# frozen_string_literal: true
+class JSONFailureApp < Devise::FailureApp
+  def respond
+    if request.format == :json
+      json_failure
+    else
+      super
+    end
+  end
+
+  def json_failure
+    self.status = 401
+    self.content_type = 'application/json'
+    self.response_body = { code: "unauthorized", message: i18n_message }.to_json
+  end
+end

--- a/config/initializers/core_extensions/devise/strategies/jwt.rb
+++ b/config/initializers/core_extensions/devise/strategies/jwt.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+# frozen_string_literal: true
+module Devise
+  module Strategies
+    class JWT < Base
+      include ActionController::HttpAuthentication::Token
+
+      def valid?
+        auth_params.present?
+      end
+
+      def authenticate!
+        return fail! unless claims
+        return fail! unless claims.key?(:user_id)
+        return fail! if claims.key?(:token) && !AuthToken.exists?(token: claims[:token])
+
+        success!(User.find(claims[:user_id]))
+      end
+
+      protected def auth_params
+        auth_params, _options = token_and_options(request)
+        auth_params
+      end
+
+      protected def claims
+        ::JsonWebToken.decode(auth_params)
+      rescue
+        nil
+      end
+    end
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,6 +6,9 @@ Devise.setup do |config|
   config.warden do |manager|
     manager.default_strategies(scope: :user).unshift :two_factor_authenticatable
     manager.default_strategies(scope: :user).unshift :two_factor_backupable
+    manager.strategies.add(:jwt, Devise::Strategies::JWT)
+    manager.default_strategies(scope: :user).unshift :jwt
+    manager.failure_app = JSONFailureApp
   end
 
   # ==> Mailer Configuration

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -1,7 +1,8 @@
 development:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] || '779a989560545187f66c9783dd837e4b9b7aa7051d3e6b34f35d3af313a129ab9fc33102c86f60771237fefc85b686d31c878e0b853d23f45e091b2528fb41bf' %>
   devise: <%= ENV["DEVISE_SECRET"] || '779a989560545187f66c9783dd837e4b9b7aa7051d3e6b34f35d3af313a129ab9fc33102c86f60771237fefc85b686d31c878e0b853d23f45e091b2528fb41bf' %>
-  devise_otp: <%= ENV["DEVISE_JWT_SECRET"] || '779a989560545187f66c9783dd837e4b9b7aa7051d3e6b34f35d3af313a129ab9fc33102c86f60771237fefc85b686d31c878e0b853d23f45e091b2528fb41bf' %>
+  devise_jwt: <%= ENV["DEVISE_JWT_SECRET"] || '779a989560545187f66c9783dd837e4b9b7aa7051d3e6b34f35d3af313a129ab9fc33102c86f60771237fefc85b686d31c878e0b853d23f45e091b2528fb41bf' %>
+  jwt_expiration: <%= 24.hours.to_i %>
   devise_otp: <%= ENV["DEVISE_OTP_SECRET"] || '779a989560545187f66c9783dd837e4b9b7aa7051d3e6b34f35d3af313a129ab9fc33102c86f60771237fefc85b686d31c878e0b853d23f45e091b2528fb41bf' %>
   devise_otp_issuer: Reckoning.io
   ga: <%= ENV["GOOGLE_ANALYTICS"] %>
@@ -26,6 +27,7 @@ test:
   secret_key_base: secret
   devise: devise
   devise_jwt: devise_jwt
+  jwt_expiration: <%= 24.hours.to_i %>
   devise_otp: devise_otp
   devise_otp_issuer: Reckoning.io
   ga:
@@ -48,6 +50,7 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   devise: <%= ENV["DEVISE_SECRET"] %>
   devise_jwt: <%= ENV["DEVISE_JWT_SECRET"] %>
+  jwt_expiration: <%= 24.hours.to_i %>
   devise_otp: <%= ENV["DEVISE_OTP_SECRET"] %>
   devise_otp_issuer: Reckoning.io
   ga: <%= ENV["GOOGLE_ANALYTICS"] %>

--- a/db/migrate/20170506185108_remove_scope_from_auth_tokens.rb
+++ b/db/migrate/20170506185108_remove_scope_from_auth_tokens.rb
@@ -1,0 +1,6 @@
+class RemoveScopeFromAuthTokens < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :auth_tokens, :scope, :string
+    AuthToken.delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170417085324) do
+ActiveRecord::Schema.define(version: 20170506185108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,12 +38,11 @@ ActiveRecord::Schema.define(version: 20170417085324) do
   end
 
   create_table "auth_tokens", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "user_id",                        null: false
+    t.uuid     "user_id",     null: false
     t.string   "token"
     t.text     "description"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.string   "scope",       default: "system"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.string   "user_agent"
     t.integer  "expires"
     t.index ["token"], name: "index_auth_tokens_on_token", using: :btree

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -1,18 +1,19 @@
 # encoding: utf-8
 # frozen_string_literal: true
-class JsonWebToken
-  class << self
-    def encode(payload)
-      JWT.encode(payload, Rails.application.secrets[:devise_jwt])
-    end
+module JsonWebToken
+  module_function
 
-    def decode(token)
-      body = JWT.decode(token, Rails.application.secrets[:devise_jwt])[0]
-      HashWithIndifferentAccess.new body
-      # rubocop:disable Lint/RescueException
-    rescue Exception => e
-      Rails.logger.debug(e)
-      nil
-    end
+  def encode(payload)
+    payload = payload.dup
+    payload[:iss] = "Reckoning.io"
+
+    JWT.encode(payload, Rails.application.secrets[:devise_jwt])
+  end
+
+  def decode(token)
+    decoded_token = JWT.decode(token, Rails.application.secrets[:devise_jwt])
+    HashWithIndifferentAccess.new(decoded_token.first)
+  rescue
+    nil
   end
 end

--- a/test/support/session_helper.rb
+++ b/test/support/session_helper.rb
@@ -8,6 +8,7 @@ module SessionHelper
 
   def http_authorization(user)
     token = AuthToken.find_or_create_by(user_id: user.id)
-    ActionController::HttpAuthentication::Token.encode_credentials(token.token)
+    jwt = JsonWebToken.encode(token.to_jwt_payload)
+    ActionController::HttpAuthentication::Token.encode_credentials(jwt)
   end
 end


### PR DESCRIPTION
There are now two types of jwt Tokens used in the App. Short Term Tokens which expire after some hours
for the use in the angular frontend for example and Tokens without or with longer expiration times for use in
API clients, Mobile Apps etc. The latter includes an auth_token which is generated and saved in a db table with
the used user agent. This allows the User to see which user agents are accessing his data and can remove access
to a device for example.