### PR TITLE
chore(infra): bump Postgres 13→17, Redis 6→7.4, Node 18→22

### DIFF
--- a/.github/workflows/e2e-tests.job.yml
+++ b/.github/workflows/e2e-tests.job.yml
@@ -25,7 +25,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.2-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: root
           POSTGRES_DB: fleetyards_test
@@ -38,7 +38,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:6.2.10-alpine
+        image: redis:7.4-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.2-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: root
           POSTGRES_DB: fleetyards_test
@@ -28,7 +28,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:6.2.10-alpine
+        image: redis:7.4-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/seeds.job.yml
+++ b/.github/workflows/seeds.job.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.2-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: root
           POSTGRES_DB: fleetyards_test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 ruby 3.2.2
-nodejs 18.13.0
+nodejs 22.11.0
 pnpm 10.13.1
 bun 1.1.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 name: reckoning-dev
 services:
   postgres:
-    image: postgres:13-alpine
+    image: postgres:17-alpine
     restart: always
     environment:
       POSTGRES_USER: root
@@ -11,7 +11,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
   redis:
-    image: redis:6.2.11-alpine
+    image: redis:7.4-alpine
     ports:
       - 8242:6379
     volumes:


### PR DESCRIPTION
## Summary

PR 3 in the P0 modernization series. Bumps EOL/near-EOL infrastructure versions.

| Component | Before | After | Why |
|---|---|---|---|
| Postgres | 13.x | 17 | PG 13 EOL Nov 2025 |
| Redis | 6.2.x | 7.4 | Redis 6.x out of support |
| Node | 18.13.0 | 22.11.0 | Node 18 EOL April 2025 |

Updates `docker-compose.yml`, `.tool-versions`, and the three CI workflow files that pin a service version (`ruby-tests.job.yml`, `e2e-tests.job.yml`, `seeds.job.yml`).

## Heads up for local devs

The named `postgres` volume contains PG 13 data files that PG 17 cannot open. After pulling this branch:

- **Quickest path** (dev data is disposable): `docker compose down -v` to drop the volume, then `docker compose up -d` and reseed.
- **Preserve data**: `pg_dump` from PG 13 first, then restore into PG 17 after the bump.

## Test plan

- [ ] All CI jobs pass against the new service images
- [ ] Local boot works against fresh PG 17 + Redis 7 containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)