### PR TITLE
chore(ci): wire bundler-audit as a hard PR gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,10 @@ jobs:
     needs: ruby-setup
     uses: ./.github/workflows/brakeman.job.yml
 
+  ruby-audit:
+    needs: ruby-setup
+    uses: ./.github/workflows/ruby-audit.job.yml
+
   ruby-tests:
     needs: ruby-setup
     uses: ./.github/workflows/ruby-tests.job.yml
@@ -45,7 +49,7 @@ jobs:
 
   deploy:
     if: github.ref == 'refs/heads/main'
-    needs: [ruby-lint, brakeman, ruby-tests, seeds, e2e-tests]
+    needs: [ruby-lint, brakeman, ruby-audit, ruby-tests, seeds, e2e-tests]
     uses: ./.github/workflows/deploy.job.yml
     with:
       capEnv: live

--- a/.github/workflows/ruby-audit.job.yml
+++ b/.github/workflows/ruby-audit.job.yml
@@ -14,4 +14,13 @@ jobs:
       - name: Update Audit DB
         run: bundle exec bundle-audit update
       - name: Check Audit DB
-        run: bundle exec bundle-audit check
+        # Baseline ignores — kept narrow on purpose so any new advisory
+        # against sinatra (or any other gem) fails the build.
+        # - GHSA-hxx2-7vcw-mqr3 / CVE-2024-21510 (sinatra ReDoS, fixed in 4.1.0)
+        # - GHSA-mr3q-g2mv-mr4q / CVE-2025-61921 (sinatra ReDoS, fixed in 4.2.0)
+        # Both require sinatra >= 4, which needs rack 3, which needs
+        # dropping redis-actionpack/redis-rack — tracked as a separate
+        # P2 refactor.
+        run: |
+          bundle exec bundle-audit check \
+            --ignore GHSA-hxx2-7vcw-mqr3 GHSA-mr3q-g2mv-mr4q


### PR DESCRIPTION
## Summary

Closes the last open P0 item: makes `bundler-audit` a required PR check. New CVEs against dependencies will now fail the build before merge instead of accumulating silently.

## Changes

- `main.yml`: adds `ruby-audit` to the per-PR job graph and to the `deploy` job's `needs:`.
- `ruby-audit.job.yml`: passes `--ignore GHSA-hxx2-7vcw-mqr3 GHSA-mr3q-g2mv-mr4q` for the two known sinatra ReDoS advisories. Both need `sinatra >= 4`, which needs `rack 3`, which needs the `redis-actionpack` → `:redis_cache_store` refactor on the P2 list. The ignore list is intentionally narrow (only those two IDs, not a blanket skip).

## Local verification

```
$ bundle exec bundle-audit check --ignore GHSA-hxx2-7vcw-mqr3 GHSA-mr3q-g2mv-mr4q
No vulnerabilities found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)