### PR TITLE
chore(ci): expand Dependabot — add github-actions + grouped weekly bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,33 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      bundler-patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- **Add `github-actions` ecosystem** so action pins (`actions/checkout`, `ruby/setup-ruby`, etc.) get Dependabot PRs. Today these only get refreshed manually.
- **Bump cadence from monthly → weekly** so security-relevant updates surface faster.
- **Group patch + minor bumps per ecosystem** so one consolidated PR lands per week instead of N tiny PRs. Major bumps still come through individually (where review attention is needed).

## Result

| Ecosystem | Cadence | Grouped? | PR cap |
|---|---|---|---|
| `bundler` | weekly | patch + minor | 10 |
| `npm` | weekly | patch + minor | 5 |
| `github-actions` | weekly | all | 5 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)