### PR TITLE
chore(ci): temporarily disable deploy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,11 @@ jobs:
     uses: ./.github/workflows/e2e-tests.job.yml
     secrets: inherit
 
+  # Deploy is temporarily disabled while the P0 modernization series settles.
+  # Re-enable by removing `false &&` once the live environment has been
+  # smoke-tested against the new Ruby 3.4 / Rails 7.2 / PG 17 / Redis 7 stack.
   deploy:
-    if: github.ref == 'refs/heads/main'
+    if: false && github.ref == 'refs/heads/main'
     needs: [ruby-lint, brakeman, ruby-audit, ruby-tests, seeds, e2e-tests]
     uses: ./.github/workflows/deploy.job.yml
     with:


### PR DESCRIPTION
## Summary

Adds a `false &&` guard to the `deploy` job in `main.yml` so merges to `main` no longer trigger an automatic Capistrano deploy. All other jobs (lint, brakeman, audit, tests, e2e, seeds) still run on every PR.

## Why

The recent P0 series shipped a lot: Ruby 3.4, Rails 7.2, PG 17, Redis 7.4, Node 22, sessions/cache refactor off `redis-actionpack`, several major gem bumps. Live needs to be validated against the new stack before unattended deploys resume.

## How to re-enable

Remove `false && ` from the `if:` line. One-line revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)