### PR TITLE
chore(ci): unblock Dependabot e2e — secrets-free fallbacks

### DIFF
--- a/.github/workflows/e2e-tests.job.yml
+++ b/.github/workflows/e2e-tests.job.yml
@@ -17,6 +17,13 @@ jobs:
       TEST_SEEDS: 1
       RAILS_ENV: ci
       RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      # Test-only fallback values so Dependabot/fork PRs (which don't
+      # inherit repo secrets) still boot Rails. Production / staging
+      # inject real secrets via the deploy environment.
+      SECRET_KEY_BASE: ci-secret-key-base-not-used-outside-tests
+      DEVISE_SECRET: ci-devise-secret-not-used-outside-tests
+      DEVISE_JWT_SECRET: ci-devise-jwt-secret-not-used-outside-tests
+      DEVISE_OTP_SECRET: ci-devise-otp-secret-not-used-outside-tests
       VITE_RUBY_MODE: production
       ON_SUBDOMAIN: false
       RAILS_SERVE_STATIC_FILES: 1
@@ -67,8 +74,10 @@ jobs:
           wait-on: "http://localhost:8270"
           wait-on-timeout: 120
           browser: chrome
-          record: true
-          parallel: true
+          # Recording + parallel need CYPRESS_RECORD_KEY, which Dependabot
+          # / fork PRs don't have. Fall back to a single-runner local run.
+          record: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
+          parallel: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
         env:
           PORT: 8270
           CYPRESS_BASE_URL: http://localhost:8270


### PR DESCRIPTION
## Summary

Dependabot-authored PRs don't inherit repo secrets, so every Dependabot bump was failing the `e2e-tests` check with:

```
ArgumentError: Missing `secret_key_base` for 'ci' environment
```

`secrets.RAILS_MASTER_KEY` evaluates to empty for Dependabot, so credentials can't be decrypted and the secret_key_base fallback fails.

## Fix

- **Add explicit test-only fallback env vars** to `e2e-tests.job.yml` (same pattern already in `ruby-tests.job.yml`): `SECRET_KEY_BASE`, `DEVISE_SECRET`, `DEVISE_JWT_SECRET`, `DEVISE_OTP_SECRET`. These override the credentials lookup so encrypted credentials aren't needed for CI at all.
- **Gate Cypress `record:` and `parallel:` on `CYPRESS_RECORD_KEY != ''`** so Dependabot falls back to a single-node local run instead of failing on the missing dashboard key.

Once this lands, the rebased Dependabot PRs (#828, #830, #831, #833, #834, #835, #836) should go green and the auto-merge they have enabled will pick them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)