### PR TITLE
feat(frontend): install Turbo + Stimulus alongside Turbolinks (Phase 4a)

### DIFF
--- a/app/frontend/controllers/hello_controller.ts
+++ b/app/frontend/controllers/hello_controller.ts
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Smoke-test controller. Confirms the Vite glob registry is working
+// end-to-end. Drop a `<div data-controller="hello"></div>` anywhere
+// in a view and the text "Stimulus is live." appears.
+//
+// Real controllers replace legacy jQuery sprinkles one at a time
+// starting in Phase 5 — see docs/frontend-migration-plan.md.
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Stimulus is live."
+  }
+}

--- a/app/frontend/entrypoints/application.ts
+++ b/app/frontend/entrypoints/application.ts
@@ -1,10 +1,58 @@
 // Vite entrypoint — modern asset pipeline lives here.
 //
 // Loaded on every page via `<%= vite_typescript_tag "application" %>`
-// in app/views/layouts/_head.slim. Empty for now (Phase 1 of the
-// frontend migration just gets Vite running alongside Sprockets).
+// in app/views/layouts/_head.slim alongside the legacy Sprockets bundle.
 //
-// Future phases (see docs/frontend-migration-plan.md) will import
-// Turbo, Stimulus, the Tailwind stylesheet, and finally the Vue
-// islands. Until then this file ships an empty bundle — zero
-// behavior change.
+// Phase 4a of the frontend migration:
+// - Turbo is imported but DRIVE IS DISABLED. Turbolinks (legacy gem)
+//   still owns page navigation. Phase 4b flips the switch and drops
+//   Turbolinks.
+// - Stimulus IS started — fully additive, no conflict with the legacy
+//   stack. Controllers under app/frontend/controllers/ auto-register
+//   by filename (e.g. `tabs_controller.ts` → `data-controller="tabs"`).
+// - A `turbo:load → turbolinks:load` shim is installed so that when
+//   4b flips Turbo on, the 20+ existing `document.addEventListener
+//   ("turbolinks:load", …)` callsites in app/assets/javascripts/
+//   keep firing. The shim is a no-op today because Turbo isn't
+//   driving navigation yet.
+
+import { session } from "@hotwired/turbo"
+import { Application } from "@hotwired/stimulus"
+
+// Disable Turbo Drive until Phase 4b. Turbo 8's module side-effect
+// calls `start()` on import; flipping `drive` to false immediately
+// after keeps Turbo dormant so Turbolinks (still installed via
+// Sprockets) keeps owning navigation.
+session.drive = false
+
+// `turbo:load` fires once on the initial page load (and again on every
+// Turbo navigation once drive is enabled). Re-emit it as
+// `turbolinks:load` so legacy scripts under app/assets/javascripts/
+// keep working when 4b removes Turbolinks.
+document.addEventListener("turbo:load", () => {
+  document.dispatchEvent(new CustomEvent("turbolinks:load"))
+})
+
+const application = Application.start()
+
+// Vite glob: every `*_controller.ts` under app/frontend/controllers/
+// is bundled and registered. File `tabs_controller.ts` exporting a
+// default class becomes `data-controller="tabs"`.
+const controllers = import.meta.glob<{ default: typeof import("@hotwired/stimulus").Controller }>(
+  "../controllers/*_controller.ts",
+  { eager: true },
+)
+
+for (const path in controllers) {
+  const name = path
+    .split("/")
+    .pop()!
+    .replace(/_controller\.ts$/, "")
+    .replace(/_/g, "-")
+  application.register(name, controllers[path].default)
+}
+
+// Expose for browser-console debugging only in dev.
+if (import.meta.env.DEV) {
+  ;(window as unknown as { Stimulus?: Application }).Stimulus = application
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "test:e2e:report": "generate-mochawesome-report --jsonDir test/reports/e2e --output test/reports/e2e/html --charts"
   },
   "dependencies": {
+    "@hotwired/stimulus": "^3.2.2",
+    "@hotwired/turbo": "^8.0.23",
     "pdfjs-dist": "3.11.174",
     "puppeteer": "^23.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@hotwired/stimulus':
+        specifier: ^3.2.2
+        version: 3.2.2
+      '@hotwired/turbo':
+        specifier: ^8.0.23
+        version: 8.0.23
       pdfjs-dist:
         specifier: 3.11.174
         version: 3.11.174
@@ -210,6 +216,13 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@hotwired/stimulus@3.2.2':
+    resolution: {integrity: sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==}
+
+  '@hotwired/turbo@8.0.23':
+    resolution: {integrity: sha512-GZ7cijxEZ6Ig71u7rD6LHaRv/wcE/hNsc+nEfiWOkLNqUgLOwo5MNGWOy5ZV9ZUDSiQx1no7YxjTNnT4O6//cQ==}
+    engines: {node: '>= 18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1875,6 +1888,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@hotwired/stimulus@3.2.2': {}
+
+  '@hotwired/turbo@8.0.23': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:


### PR DESCRIPTION
## Summary

Phase 4a of the frontend migration. Ships the Hotwire toolchain through Vite so it can be wired up incrementally. **Turbo Drive is intentionally disabled at runtime** (`session.drive = false`) — Turbolinks (legacy sprockets gem) still owns page navigation. Phase 4b will flip the switch, rename `data-turbolinks` → `data-turbo`, fix Devise sign-out, and drop the Turbolinks gem.

## What changed

- `pnpm add @hotwired/turbo @hotwired/stimulus` (Turbo 8.0.23, Stimulus 3.2.2)
- `app/frontend/entrypoints/application.ts`:
  - imports Turbo (which auto-starts) and immediately sets `session.drive = false` to keep it dormant
  - installs a `turbo:load → turbolinks:load` shim so the 20+ existing `document.addEventListener("turbolinks:load", …)` callsites under `app/assets/javascripts/` keep firing once 4b enables Turbo
  - starts Stimulus with a Vite glob registry: every `app/frontend/controllers/*_controller.ts` exporting a default Controller class auto-registers (filename `tabs_controller.ts` → `data-controller=\"tabs\"`)
  - exposes `window.Stimulus` in dev only for console debugging
- `app/frontend/controllers/hello_controller.ts` — smoke-test controller. Drop `<div data-controller=\"hello\"></div>` anywhere in a view and it renders \"Stimulus is live.\"

## Deferred

The `tabs.js → tabs_controller.ts` port called out in the migration plan is deferred to Phase 5 — it depends on Bootstrap 3 still owning the visual tab toggle (Phase 9 territory), so a partial port now would just be churn.

## Test plan

- [x] `pnpm exec vite build` produces a 139 KB JS bundle (Turbo + Stimulus + hello controller) — within expected range
- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean
- [x] `bundle exec standardrb` reports no offenses
- [ ] Drop `<div data-controller=\"hello\"></div>` into the dashboard and confirm \"Stimulus is live.\" renders
- [ ] Confirm in dev console that `Stimulus` is defined and `session.drive` is `false`
- [ ] Confirm Turbolinks navigation still works exactly as before (because Turbo isn't driving yet)

Generated with [Claude Code](https://claude.com/claude-code)