### PR TITLE
feat(projects): wrap projects index in a Turbo Frame (Phase 5 batch 1)

### DIFF
--- a/app/assets/javascripts/helpers/noty.coffee
+++ b/app/assets/javascripts/helpers/noty.coffee
@@ -95,11 +95,15 @@ window.displayError = (text, timeout) ->
   timeout = false if timeout is undefined
   displayNoty(text, 'error', timeout)
 
-document.addEventListener "turbolinks:load", () ->
-  $("[data-notyConfirm]").click (ev) ->
-    displayConfirm(ev, $(@))
-    return false
+# Delegated so the handler keeps working when Turbo Frame swaps in
+# new [data-notyConfirm] elements (e.g. project archive button after
+# a pagination/filter navigation). Bound once at script load — the
+# document survives both Turbo Drive and Turbo Frame navigations.
+$(document).on "click", "[data-notyConfirm]", (ev) ->
+  displayConfirm(ev, $(@))
+  return false
 
+document.addEventListener "turbolinks:load", () ->
   success = $('body').data('success');
   displaySuccess(success) if success
 

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -26,35 +26,44 @@
       </div>
     </div>
 
-    <div class="row">
-      <div class="col-xs-12 col-md-6 filters">
-        <div class="btn-group">
-          <% if params.fetch(:state, nil) %>
-            <a class="btn btn-default" href="<%= url_for(state: nil) %>">
-              <%= I18n.t(:"filter.project_state.all") %>
-            </a>
-          <% else %>
-            <a class="btn btn-default" href="<%= url_for(state: :archived) %>">
-              <%= I18n.t(:"filter.project_state.archived") %>
-            </a>
-          <% end %>
+    <%# Turbo Frame around filter + pagination + list. Filter and
+        pagination links inside the frame issue Turbo requests; the
+        controller re-renders the same template and Turbo extracts the
+        matching frame and swaps just this region. `data-turbo-action=
+        "advance"` updates the URL so the filter/page is shareable.
+        First Phase 5 (Turbo Frames on CRUD) PR — see
+        docs/frontend-migration-plan.md. %>
+    <turbo-frame id="projects-list" data-turbo-action="advance">
+      <div class="row">
+        <div class="col-xs-12 col-md-6 filters">
+          <div class="btn-group">
+            <% if params.fetch(:state, nil) %>
+              <a class="btn btn-default" href="<%= url_for(state: nil) %>">
+                <%= I18n.t(:"filter.project_state.all") %>
+              </a>
+            <% else %>
+              <a class="btn btn-default" href="<%= url_for(state: :archived) %>">
+                <%= I18n.t(:"filter.project_state.archived") %>
+              </a>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-xs-12 col-md-6">
+          <%= paginate @projects %>
         </div>
       </div>
-      <div class="col-xs-12 col-md-6">
-        <%= paginate @projects %>
+
+      <%= render partial: "list" %>
+
+      <% if @projects.blank? %>
+        <%= render partial: "shared/blank" %>
+      <% end %>
+
+      <div class="row">
+        <div class="col-xs-12">
+          <%= paginate @projects %>
+        </div>
       </div>
-    </div>
-
-    <%= render partial: "list" %>
-
-    <% if @projects.blank? %>
-      <%= render partial: "shared/blank" %>
-    <% end %>
-
-    <div class="row">
-      <div class="col-xs-12">
-        <%= paginate @projects %>
-      </div>
-    </div>
+    </turbo-frame>
   </div>
 </div>


### PR DESCRIPTION
## Summary

First Phase 5 PR — Turbo Frames on CRUD screens.

**Scope substitution:** the migration plan called this batch \"Customer list/detail\", but customers don't have a separate list/index page in this app (they're settings entities managed through projects). The projects index is the actual high-traffic CRUD list page, so it's the right first target. Subsequent batches will follow the plan's order (offers, invoices, settings, dashboard).

## What changed

- **`app/views/projects/index.html.erb`** — wrap filter + pagination + list + blank-state + bottom pagination in `<turbo-frame id=\"projects-list\" data-turbo-action=\"advance\">`. Clicking the all/archived filter or any paginate link issues a Turbo Frame request; the controller re-renders the same template and Turbo swaps just this region. `advance` keeps the URL in sync so a filtered/paginated view is shareable + browser-back-friendly.
- **`app/assets/javascripts/helpers/noty.coffee`** — switch the `[data-notyConfirm]` click handler from per-element binding (inside the `turbolinks:load` listener) to delegated binding on `document`. Without this, projects archived/deleted **inside** the frame would lose their confirm-dialog handlers after a frame swap.

No server-side controller changes needed — when a request matches a Turbo Frame id, Turbo extracts that frame from the full response on its own.

## Test plan

- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean
- [x] `bundle exec standardrb` reports no offenses
- [x] `pnpm exec vite build` succeeds (JS bundle size unchanged)
- [ ] **Manual browser smoke-test (cannot do from here):**
  - Visit `/projects` → click the \"archived\" filter button → confirm only the list region swaps (URL updates, top header stays, no full reload)
  - Click pagination → confirm only the list region swaps
  - Open the actions dropdown on an active project → \"Archive\" → confirm the noty dialog appears, confirm archives, page reloads
  - Open `/projects?state=archived` → click \"Unarchive\" → confirm it works via Turbo's `data-turbo-method=put`

## Out of scope

- The customer edit form (the literal \"customer\" target) — that page has datepickers + Bootstrap tooltips that need legacy JS init on every render; deferring until those have Stimulus controllers
- Updating other `[data-notyConfirm]` handler bindings — only noty was switched to delegated. Bootstrap dropdowns are already delegated natively, and Bootstrap tooltips degrade silently (visual-only)

Generated with [Claude Code](https://claude.com/claude-code)