### PR TITLE
feat(offers): wrap offers index in a Turbo Frame (Phase 5 batch 2)

### DIFF
--- a/app/views/offers/index.html.erb
+++ b/app/views/offers/index.html.erb
@@ -25,26 +25,32 @@
       </div>
     </div>
 
-    <div class="row">
-      <div class="col-xs-12 col-md-6 filters">
-        <%= render "shared/tables/filter", resource: "offer", name: "state", filters: Offer.aasm.states.map(&:name), translateable: true %>
-        <%= render "shared/tables/filter", resource: "offer", name: "year", filters: current_offer_years %>
+    <%# Turbo Frame around filters, sortable list, pagination — same
+        pattern as projects/index (Phase 5 batch 1). Filter/sort/page
+        clicks update just this region. `advance` keeps the URL in
+        sync so a filtered view is shareable + browser-back-friendly. %>
+    <turbo-frame id="offers-list" data-turbo-action="advance">
+      <div class="row">
+        <div class="col-xs-12 col-md-6 filters">
+          <%= render "shared/tables/filter", resource: "offer", name: "state", filters: Offer.aasm.states.map(&:name), translateable: true %>
+          <%= render "shared/tables/filter", resource: "offer", name: "year", filters: current_offer_years %>
+        </div>
+        <div class="col-xs-12 col-md-6">
+          <%= paginate @offers %>
+        </div>
       </div>
-      <div class="col-xs-12 col-md-6">
-        <%= paginate @offers %>
-      </div>
-    </div>
 
-    <% if @offers.present? %>
-      <%= render partial: "offers/list", :@offers => @offers %>
-    <% else %>
-      <%= render partial: "shared/blank" %>
-    <% end %>
+      <% if @offers.present? %>
+        <%= render partial: "offers/list", "@offers": @offers %>
+      <% else %>
+        <%= render partial: "shared/blank" %>
+      <% end %>
 
-    <div class="row">
-      <div class="col-xs-12 col-md-6">
-        <%= paginate @offers %>
+      <div class="row">
+        <div class="col-xs-12 col-md-6">
+          <%= paginate @offers %>
+        </div>
       </div>
-    </div>
+    </turbo-frame>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Same pattern as #873 (projects index, Phase 5 batch 1) applied to the offers list. Wraps filter dropdowns (state, year), sortable column headers, paginate links, and the list itself in a single `<turbo-frame id=\"offers-list\" data-turbo-action=\"advance\">`. Clicking any filter/sort/pagination link swaps just the frame; the chrome (header + \"New offer\" button) stays put. `advance` updates the URL so filtered views are shareable + browser-back works.

The deeper **Turbo Stream** work for inline state transitions (`created → bided → accepted`) that the plan calls out for offers is **deferred** — that's a separate PR with controller changes and stream templates.

No server-side change required (Turbo extracts the matching frame from the full response automatically).

## Test plan

- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean
- [x] `bundle exec standardrb` reports no offenses
- [ ] Manual browser smoke-test:
  - Visit `/offers` → change the state filter dropdown → confirm only the list region swaps (URL updates, chrome stays)
  - Click pagination → same
  - Click a sortable column header → same
  - Open an individual offer to confirm the offer's own page still loads normally (the frame doesn't try to grab a non-matching response)

Generated with [Claude Code](https://claude.com/claude-code)