### PR TITLE
feat(invoices): wrap invoices index in a Turbo Frame (Phase 5 batch 3)

### DIFF
--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -27,31 +27,37 @@
       </div>
     </div>
 
-    <div class="row">
-      <div class="col-xs-12 col-md-8 filters">
-        <%= render "shared/tables/filter", resource: "invoice", name: "state", filters: Invoice.workflow_spec.state_names, translateable: true %>
-        <%= render "shared/tables/filter", resource: "invoice", name: "year", filters: current_invoice_years %>
-        <%= render "shared/tables/filter", resource: "invoice", name: "quarter", filters: quarters, translateable: "date.quarters" %>
-        <%= render "shared/tables/filter", resource: "invoice", name: "month", filters: months, translateable: "date.month_names" %>
-        <%= render "shared/tables/filter", resource: "invoice", name: "paid_in_year", filters: current_invoice_years %>
-        <%= render "shared/tables/filter", resource: "invoice", name: "paid_in_quarter", filters: quarters, translateable: "date.quarters" %>
-        <%= render "shared/tables/filter", resource: "invoice", name: "paid_in_month", filters: months, translateable: "date.month_names" %>
+    <%# Turbo Frame around filters, list, pagination — same pattern as
+        #873 (projects) and #874 (offers). Invoices have 7 filter
+        dropdowns (state, year, quarter, month, plus paid_in_* trio)
+        plus sortable columns — all benefit from partial swap. %>
+    <turbo-frame id="invoices-list" data-turbo-action="advance">
+      <div class="row">
+        <div class="col-xs-12 col-md-8 filters">
+          <%= render "shared/tables/filter", resource: "invoice", name: "state", filters: Invoice.workflow_spec.state_names, translateable: true %>
+          <%= render "shared/tables/filter", resource: "invoice", name: "year", filters: current_invoice_years %>
+          <%= render "shared/tables/filter", resource: "invoice", name: "quarter", filters: quarters, translateable: "date.quarters" %>
+          <%= render "shared/tables/filter", resource: "invoice", name: "month", filters: months, translateable: "date.month_names" %>
+          <%= render "shared/tables/filter", resource: "invoice", name: "paid_in_year", filters: current_invoice_years %>
+          <%= render "shared/tables/filter", resource: "invoice", name: "paid_in_quarter", filters: quarters, translateable: "date.quarters" %>
+          <%= render "shared/tables/filter", resource: "invoice", name: "paid_in_month", filters: months, translateable: "date.month_names" %>
+        </div>
+        <div class="col-xs-12 col-md-4">
+          <%= paginate @invoices %>
+        </div>
       </div>
-      <div class="col-xs-12 col-md-4">
-        <%= paginate @invoices %>
-      </div>
-    </div>
 
-    <% if @invoices.present? %>
-      <%= render partial: "invoices/list", :@invoices => @invoices %>
-    <% else %>
-      <%= render partial: "shared/blank" %>
-    <% end %>
+      <% if @invoices.present? %>
+        <%= render partial: "invoices/list", "@invoices": @invoices %>
+      <% else %>
+        <%= render partial: "shared/blank" %>
+      <% end %>
 
-    <div class="row">
-      <div class="col-xs-12 col-md-6">
-        <%= paginate @invoices %>
+      <div class="row">
+        <div class="col-xs-12 col-md-6">
+          <%= paginate @invoices %>
+        </div>
       </div>
-    </div>
+    </turbo-frame>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Same pattern as #873 (projects) and #874 (offers) applied to the invoices list. Wraps the seven filter dropdowns (state, year, quarter, month, paid_in_year, paid_in_quarter, paid_in_month), sortable column headers, paginate links, and the list itself in a single `<turbo-frame id=\"invoices-list\" data-turbo-action=\"advance\">`.

Clicking any filter/sort/pagination link swaps just the frame; the chrome (h1 with totals + \"New invoice\" button) stays put. `advance` updates the URL so filtered views are shareable + browser-back works.

No server-side change required.

## Test plan

- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean
- [x] `bundle exec standardrb` reports no offenses
- [ ] Manual browser smoke-test:
  - Visit `/invoices` → cycle through each of the 7 filter dropdowns → confirm only the list region swaps
  - Pagination → same
  - Sortable columns → same
  - Open an invoice → confirm the detail page loads (no frame mismatch)

Generated with [Claude Code](https://claude.com/claude-code)