### PR TITLE
fix(css): re-color Turbo's progress bar (was styling dead .turbolinks-progress-bar)

### DIFF
--- a/app/assets/stylesheets/partials/_nprogress-custom.scss
+++ b/app/assets/stylesheets/partials/_nprogress-custom.scss
@@ -1,4 +1,7 @@
-.turbolinks-progress-bar {
+// Turbo Drive's top-of-page progress bar (Phase 4b). The nprogress
+// styles below stay for AngularJS, which still uses NProgress in
+// angular/base/app.coffee until Phase 7.
+.turbo-progress-bar {
   background-color: $navbar-active !important;
 }
 


### PR DESCRIPTION
## Summary

Phase 4b dropped the Turbolinks gem but `app/assets/stylesheets/partials/_nprogress-custom.scss` still styled the dead `.turbolinks-progress-bar` selector. Turbo Drive renders the same top-of-page progress bar via `.turbo-progress-bar` — point the brand-color override there so the navigation indicator picks up the navbar-active blue again.

The `#nprogress` rules below stay put — AngularJS still calls `NProgress.start()` / `NProgress.done()` in `angular/base/app.coffee` and will until Phase 7 drops AngularJS entirely.

## Test plan

- [ ] Navigate between pages and confirm the top progress bar appears with the navbar-active blue (matches what Turbolinks used to render)

Generated with [Claude Code](https://claude.com/claude-code)