### PR TITLE
chore(js): drop dead Angular ngGeolocation + ngmap requires

### DIFF
--- a/app/assets/javascripts/angular/init.coffee
+++ b/app/assets/javascripts/angular/init.coffee
@@ -4,5 +4,3 @@
 #= require angular-timer
 #= require angular-animate
 #= require angular-bootstrap
-#= require ngGeolocation
-#= require ngmap


### PR DESCRIPTION
## Summary

`app/assets/javascripts/angular/init.coffee` loaded `ngGeolocation` and `ngmap` into the Angular Sprockets bundle, but neither is injected into any Angular module:

- `app/assets/javascripts/angular/base/app.coffee` declares the `Reckoning` module with `['ngRoute', 'ngAnimate', 'ui.bootstrap.tpls', 'ui.bootstrap.modal']` — **no ngGeolocation, no ngMap**
- `grep -rIn 'ngGeolocation\|ngMap' app/assets/javascripts/` after removing init.coffee returns zero matches

These are leftover dependencies from the dead geolocation flow that #879 removed (no view ever rendered the trigger button, no Google Maps script was loaded so the code would have thrown immediately if invoked).

The vendored bower components (`vendor/assets/bower_components/ngmap`, `ngGeolocation`) stay on disk for now — the `bower-rails` gem cleanup is Phase 7.

## Test plan

- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean

Generated with [Claude Code](https://claude.com/claude-code)