### PR TITLE
refactor(frontend): convert datepicker init to a Stimulus controller

### DIFF
--- a/app/assets/javascripts/helpers/datetimepicker.coffee
+++ b/app/assets/javascripts/helpers/datetimepicker.coffee
@@ -78,9 +78,12 @@ window.Timepicker =
 
     picker
 
-document.addEventListener "turbolinks:load", ->
-  $('.datepicker').each ->
-    Datepicker.init($(@).find('input'))
-
-  $('.timepicker').each ->
-    Timepicker.init($(@).find('input'))
+# Datepicker init is now driven by the Stimulus
+# `datepicker_controller` (app/frontend/controllers/) which connects
+# on element insertion — including Turbo Frame swaps. The
+# `.timepicker` global init never had a callsite outside AngularJS
+# (which calls `Timepicker.init` directly from
+# angular/base/directives/timepicker.coffee), so it's dropped too.
+#
+# `window.Datepicker` / `window.Timepicker` themselves stay below
+# until Phase 7 retires the AngularJS directives that consume them.

--- a/app/frontend/controllers/datepicker_controller.ts
+++ b/app/frontend/controllers/datepicker_controller.ts
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Wraps the legacy `window.Datepicker` (pickadate.js) per element so
+// it survives Turbo Frame swaps — Stimulus reconnects whenever the
+// element is re-added to the DOM, where the old document-level
+// `turbolinks:load` init only fired on full page loads.
+//
+// `window.Datepicker` itself stays in
+// `app/assets/javascripts/helpers/datetimepicker.coffee` because the
+// AngularJS directives still call `Datepicker.init` directly. Once
+// AngularJS leaves in Phase 7, that helper moves into Vite too.
+//
+// Attach via `data-controller="datepicker"` on the
+// `<div class="input-group datepicker">` wrapper. The input inside
+// is what pickadate binds to.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Picker = { stop?: () => void } | null
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const jq: any = (window as unknown as { $: unknown }).$ ?? null
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Datepicker: any = (window as unknown as { Datepicker: unknown }).Datepicker ?? null
+
+export default class extends Controller {
+  private picker: Picker = null
+
+  connect() {
+    if (!jq || !Datepicker) return
+    const input = jq(this.element).find("input")
+    if (!input.length) return
+    this.picker = Datepicker.init(input)
+  }
+
+  disconnect() {
+    // pickadate's picker holds a popup + jQuery event bindings.
+    // Without `.stop()`, repeatedly swapping a Turbo Frame
+    // containing a datepicker would leak one picker per swap.
+    this.picker?.stop?.()
+    this.picker = null
+  }
+}

--- a/app/views/customers/_form.html.erb
+++ b/app/views/customers/_form.html.erb
@@ -22,7 +22,7 @@
           <div class="col-xs-12 col-md-6">
             <div class="form-group">
               <%= form.label :employment_date %>
-              <div class="input-group datepicker">
+              <div class="input-group datepicker" data-controller="datepicker">
                 <%= form.date_field :employment_date, class: "form-control", "data-value" => form.object.employment_date %>
                 <span class="input-group-btn">
                   <button class="btn btn-default" type="button">
@@ -35,7 +35,7 @@
           <div class="col-xs-12 col-md-6">
             <div class="form-group">
               <%= form.label :employment_end_date %>
-              <div class="input-group datepicker">
+              <div class="input-group datepicker" data-controller="datepicker">
                 <%= form.date_field :employment_end_date, class: "form-control", "data-value" => form.object.employment_end_date %>
                 <span class="input-group-btn">
                   <button class="btn btn-default" type="button">

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -30,7 +30,7 @@
     </div>
     <div class="col-xs-12 col-md-4 js-toggle-interval-once <%= expense.once? ? "" : "hide" %>">
       <div class="form-group <%= form_error?(expense, :date) %>">
-        <div class="input-group datepicker">
+        <div class="input-group datepicker" data-controller="datepicker">
           <%= form.label :date, class: "input-group-addon" %>
           <%= form.date_field :date, value: I18n.l(Time.zone.now, format: :datepicker), class: "form-control", "data-value" => form.object.date %>
           <span class="input-group-btn">
@@ -44,7 +44,7 @@
     </div>
     <div class="col-xs-12 col-md-4 js-toggle-interval-other <%= expense.once? ? "hide" : "" %>">
       <div class="form-group <%= form_error?(expense, :started_at) %>">
-        <div class="input-group datepicker">
+        <div class="input-group datepicker" data-controller="datepicker">
           <%= form.label :started_at, class: "input-group-addon" %>
           <%= form.date_field :started_at, value: I18n.l(Time.zone.now, format: :datepicker), class: "form-control", "data-value" => form.object.started_at %>
           <span class="input-group-btn">
@@ -58,7 +58,7 @@
     </div>
     <div class="col-xs-12 col-md-4 js-toggle-interval-other <%= expense.once? ? "hide" : "" %>">
       <div class="form-group <%= form_error?(expense, :ended_at) %>">
-        <div class="input-group datepicker">
+        <div class="input-group datepicker" data-controller="datepicker">
           <%= form.label :ended_at, class: "input-group-addon" %>
           <%= form.date_field :ended_at, value: I18n.l(Time.zone.now, format: :datepicker), class: "form-control", "data-value" => form.object.ended_at %>
           <span class="input-group-btn">

--- a/app/views/invoices/_form.html.erb
+++ b/app/views/invoices/_form.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="col-xs-12 col-md-4">
       <div class="form-group <%= form_error?(invoice, :date) %>">
-        <div class="input-group datepicker">
+        <div class="input-group datepicker" data-controller="datepicker">
           <%= form.label :date, class: "input-group-addon" %>
           <%= form.date_field :date, class: "form-control", "data-value" => form.object.date %>
           <span class="input-group-btn">
@@ -29,7 +29,7 @@
     </div>
     <div class="col-xs-12 col-md-4">
       <div class="form-group <%= form_error?(invoice, :pay_date) %>">
-        <div class="input-group datepicker">
+        <div class="input-group datepicker" data-controller="datepicker">
           <%= form.label :pay_date, class: "input-group-addon" %>
           <%= form.date_field :pay_date, disabled: !form.object.paid?, class: "form-control", "data-value" => form.object.pay_date %>
           <span class="input-group-btn">
@@ -51,7 +51,7 @@
       <%= form_errors invoice, :ref %>
     </div>
     <div class="col-xs-12 col-md-4 form-group">
-      <div class="input-group datepicker">
+      <div class="input-group datepicker" data-controller="datepicker">
         <%= form.label :payment_due_date, class: "input-group-addon" %>
         <%= form.date_field :payment_due_date, class: "form-control", "data-value" => form.object.payment_due_date %>
         <span class="input-group-btn">
@@ -62,7 +62,7 @@
       </div>
     </div>
     <div class="col-xs-12 col-md-4 form-group">
-      <div class="input-group datepicker">
+      <div class="input-group datepicker" data-controller="datepicker">
         <%= form.label :delivery_date, class: "input-group-addon" %>
         <%= form.date_field :delivery_date, class: "form-control", "data-value" => form.object.delivery_date %>
         <span class="input-group-btn">

--- a/app/views/offers/_form.html.erb
+++ b/app/views/offers/_form.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="col-xs-12 col-md-6">
       <div class="form-group <%= form_error?(offer, :date) %>">
-        <div class="input-group datepicker">
+        <div class="input-group datepicker" data-controller="datepicker">
           <%= form.label :date, class: "input-group-addon" %>
           <%= form.date_field :date, class: "form-control", "data-value" => form.object.date %>
           <span class="input-group-btn">

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -15,7 +15,7 @@
   </div>
   <div class="row">
     <div class="col-xs-12 col-md-6 form-group <%= form_error?(project, :start_date) %>">
-      <div class="input-group datepicker">
+      <div class="input-group datepicker" data-controller="datepicker">
         <%= form.label :start_date, class: "input-group-addon" %>
         <%= form.date_field :start_date, class: "form-control", "data-value" => form.object.start_date %>
         <span class="input-group-btn">
@@ -27,7 +27,7 @@
     </div>
 
     <div class="col-xs-12 col-md-6 form-group <%= form_error?(project, :end_date) %>">
-      <div class="input-group datepicker">
+      <div class="input-group datepicker" data-controller="datepicker">
         <%= form.label :end_date, class: "input-group-addon" %>
         <%= form.date_field :end_date, class: "form-control", "data-value" => form.object.end_date %>
         <span class="input-group-btn">


### PR DESCRIPTION
## Summary

Datepicker init used to run in a document-level `turbolinks:load` handler at the bottom of `app/assets/javascripts/helpers/datetimepicker.coffee`, iterating `$('.datepicker').each` and calling `Datepicker.init` per element. That only fires on full page loads; Turbo Frame swaps don't trigger it, so any datepicker inside a frame would lose its picker on the next swap.

This PR replaces the global init with a Stimulus controller scoped to each `.input-group.datepicker` wrapper, unblocking Turbo Frame on the customer + account edit forms (the deferred Phase 5 batches).

## What changed

- **`app/frontend/controllers/datepicker_controller.ts`** — calls `window.Datepicker.init(input)` on `connect()` and `picker.stop()` on `disconnect()` so pickadate releases its popup + jQuery event bindings between mounts (no leak on repeated frame swaps).
- **12 `.input-group.datepicker` divs** across `customers/_form`, `offers/_form`, `invoices/_form`, `expenses/_form`, `projects/_form` pick up `data-controller=\"datepicker\"`.
- **The global `turbolinks:load` block in `helpers/datetimepicker.coffee` is gone.** The `.timepicker` half was also dropped — no view ever rendered `.timepicker`, and the AngularJS directive at `angular/base/directives/timepicker.coffee` calls `Timepicker.init` directly from its own scope.

## What's intentionally kept

`window.Datepicker` / `window.Timepicker` themselves stay in `helpers/datetimepicker.coffee` — the AngularJS directives in `angular/base/directives/{datepicker,timepicker,datepicker-button}.coffee` still call them. Both globals retire in Phase 7 with AngularJS.

## Why this matters now

Phase 5 batches 4–5 (settings tabs + dashboard) and any future frame-wrapping of customer/account edit forms have been blocked by the datepicker init dependency. With this controller in place, datepickers re-initialize cleanly on every Turbo Frame swap.

## Test plan

- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean
- [x] `bundle exec standardrb` reports no offenses
- [x] `pnpm exec vite build` succeeds (bundle 142 KB, +0.4 KB for the controller)
- [x] Manual browser smoke-test:
  - Visit `/invoices/<id>/edit`, `/offers/<id>/edit`, an expense edit, `/projects/<id>/edit`, a customer edit
  - Confirm each datepicker opens / closes / submits a date as before
  - Open the calendar via clicking the date input AND via the calendar-icon button
  - Bonus: leave the page and come back — confirm no console errors / no leaked pickadate popups

Generated with [Claude Code](https://claude.com/claude-code)