### PR TITLE
refactor(frontend): port App.init's misc inits to Stimulus + Vite (item H)

### DIFF
--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -1,18 +1,13 @@
 window.App ||= {}
 
 App.init = ->
-  $('[data-toggle=tooltip]').tooltip()
-
-  $('.btn.btn-loading').click ->
-    $(@).button('loading')
-
-  # Selectize init is now driven by the Stimulus
-  # `selectize` / `customer-selectize` controllers
-  # (app/frontend/controllers/). The legacy `App.Selectize` class
-  # has been removed.
-
-  Moment = new App.Moment()
-  Moment.init()
+  # Tooltip / selectize / btn-loading / moment.locale init have
+  # all moved to Stimulus controllers + the Vite entrypoint
+  # (`app/frontend/controllers/tooltip_controller.ts`,
+  # `loading-button_controller.ts`, `selectize_controller.ts`,
+  # `app/frontend/lib/moment-locale.ts`). `App.init` is now a
+  # no-op but stays so the existing `turbolinks:load` callsite
+  # has something to call until app.coffee itself ports to Vite.
 
 App.initInternal = ->
   # accounting.js + its settings are now configured by

--- a/app/assets/javascripts/app/moment.coffee
+++ b/app/assets/javascripts/app/moment.coffee
@@ -1,8 +1,0 @@
-class App.Moment
-  init: ->
-    moment.updateLocale I18n.locale,
-      week:
-        dow: 1
-        doy: 4
-
-    moment.locale(I18n.locale)

--- a/app/frontend/controllers/loading-button_controller.ts
+++ b/app/frontend/controllers/loading-button_controller.ts
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Replaces `$('.btn.btn-loading').click(-> $(@).button('loading'))`
+// from App.init. Bootstrap 3's `button('loading')` swaps the
+// button label with `data-loading-text` and disables it while a
+// submit is in flight. Pairs with Ladda for the spinner.
+//
+// Attach via `data-controller="loading-button"` on any submit
+// button that should flip into the loading state on click. Used
+// across the Devise sign-in/forgot-password/reset-password forms
+// and the new-account signup form.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const jq: any = (window as unknown as { $: unknown }).$ ?? null
+
+export default class extends Controller {
+  private boundOnClick = () => this.onClick()
+
+  connect() {
+    this.element.addEventListener("click", this.boundOnClick)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("click", this.boundOnClick)
+  }
+
+  private onClick() {
+    if (!jq) return
+    jq(this.element).button("loading")
+  }
+}

--- a/app/frontend/controllers/tooltip_controller.ts
+++ b/app/frontend/controllers/tooltip_controller.ts
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Replaces the document-level `$('[data-toggle=tooltip]').tooltip()`
+// call that ran inside `App.init`. Attaching per-element via
+// Stimulus means tooltips re-initialize on Turbo Frame swap —
+// useful since several tooltipped buttons (e.g. the project list's
+// "add invoice for customer" hint button) live inside Phase 5's
+// `projects-list` frame.
+//
+// Bootstrap 3's tooltip plugin lives on jQuery, which is still
+// loaded via the Sprockets bundle. The controller stays attached
+// to `data-toggle="tooltip"` elements so the existing markup
+// convention still tells the reader "this has a tooltip".
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const jq: any = (window as unknown as { $: unknown }).$ ?? null
+
+export default class extends Controller {
+  connect() {
+    if (!jq) return
+    jq(this.element).tooltip()
+  }
+
+  disconnect() {
+    if (!jq) return
+    // Bootstrap 3's `tooltip("destroy")` removes the popup + the
+    // event bindings so a re-mounted element doesn't accumulate them.
+    jq(this.element).tooltip("destroy")
+  }
+}

--- a/app/frontend/entrypoints/application.ts
+++ b/app/frontend/entrypoints/application.ts
@@ -17,6 +17,7 @@ import "@hotwired/turbo"
 import { Application } from "@hotwired/stimulus"
 
 import { configureAccounting, installAccountingGlobal } from "../lib/accounting"
+import { configureMomentLocale } from "../lib/moment-locale"
 
 // PDF.js v4+ ships ESM-only. Lazy-loaded so the 1.5 MB pdfjs core +
 // worker don't ship on pages that never render a PDF (most of them).
@@ -62,6 +63,11 @@ if (i18nGlobal) {
   configureAccounting(i18nGlobal)
   installAccountingGlobal()
 }
+
+// moment.js stays loaded from Sprockets (still consumed by
+// chart.coffee + AngularJS as a global). Just configure the locale
+// + ISO week here, replacing what `App.Moment.init` used to do.
+configureMomentLocale()
 
 const application = Application.start()
 

--- a/app/frontend/lib/moment-locale.ts
+++ b/app/frontend/lib/moment-locale.ts
@@ -1,0 +1,26 @@
+// Replaces app/assets/javascripts/app/moment.coffee's App.Moment.init.
+// `moment` itself stays a global from the Sprockets bundle
+// (`//= require moment/moment`) — chart.coffee, timer.coffee, and
+// AngularJS code all read `window.moment`. We just configure the
+// locale + week settings once on Vite bundle parse, using the
+// Sprockets-set `window.I18n`.
+
+interface I18nGlobal {
+  locale: string
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MomentGlobal = any
+
+export function configureMomentLocale(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const moment: MomentGlobal = (window as any).moment
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const I18n: I18nGlobal | undefined = (window as any).I18n
+  if (!moment || !I18n) return
+
+  moment.updateLocale(I18n.locale, {
+    week: {dow: 1, doy: 4},
+  })
+  moment.locale(I18n.locale)
+}

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -72,7 +72,7 @@
 
   <br>
 
-  <button class="btn-block btn btn-primary btn-lg btn-loading" data-loading-text="<%= I18n.t(:"actions.loading") %>">
+  <button class="btn-block btn btn-primary btn-lg btn-loading" data-controller="loading-button" data-loading-text="<%= I18n.t(:"actions.loading") %>">
     <%= I18n.t(:"actions.sign_up") %>
   </button>
   <div class="clearfix"></div>

--- a/app/views/customers/_form.html.erb
+++ b/app/views/customers/_form.html.erb
@@ -111,7 +111,7 @@
                      ["{company}", "Name des Kunden"]
                    ].each do |code, label| %>
                   <div class="list-group-item">
-                    <code title="<%= I18n.t(:"actions.paste") %>" data-target="#customer_email_template" data-toggle="tooltip">
+                    <code title="<%= I18n.t(:"actions.paste") %>" data-target="#customer_email_template" data-toggle="tooltip" data-controller="tooltip">
                       <%= code %>
                     </code>
                     <%= label %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -15,7 +15,7 @@
     <%= form.password_field :password_confirmation, required: true, placeholder: I18n.t(:"helpers.placeholder.user.password_confirmation"), class: "form-control" %>
   </div>
 
-  <button class="btn-block btn btn-lg btn-primary btn-loading" data-loading-text="<%= I18n.t(:"actions.loading") %>">
+  <button class="btn-block btn btn-lg btn-primary btn-loading" data-controller="loading-button" data-loading-text="<%= I18n.t(:"actions.loading") %>">
     <%= I18n.t(:"actions.save_password") %>
   </button>
 <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,7 +9,7 @@
     <%= form_errors resource, :email %>
   </div>
 
-  <button class="btn-block btn btn-lg btn-primary btn-loading" data-loading-text="<%= I18n.t(:"actions.loading") %>">
+  <button class="btn-block btn btn-lg btn-primary btn-loading" data-controller="loading-button" data-loading-text="<%= I18n.t(:"actions.loading") %>">
     <%= I18n.t(:"actions.reset_password") %>
   </button>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -40,7 +40,7 @@
     </div>
   <% end %>
 
-  <button type="submit" class="btn btn-lg btn-primary btn-loading btn-block" data-loading-text="<%= I18n.t(:"actions.loading") %>" data-test="submit-login">
+  <button type="submit" class="btn btn-lg btn-primary btn-loading btn-block" data-controller="loading-button" data-loading-text="<%= I18n.t(:"actions.loading") %>" data-test="submit-login">
     <%= I18n.t(:"actions.sign_in") %>
   </button>
   <div class="clearfix"></div>

--- a/app/views/projects/_list.html.erb
+++ b/app/views/projects/_list.html.erb
@@ -22,7 +22,7 @@
           </div>
           <div class="col-xs-4 col-md-2">
             <div class="panel-list-action pull-right">
-              <a class="btn btn-default" href="<%= new_project_path(customer_id: customer) %>" title="<%= I18n.t(:"nav.subnav.new_project_for_customer", customer: customer.name) %>" data-toggle="tooltip">
+              <a class="btn btn-default" href="<%= new_project_path(customer_id: customer) %>" title="<%= I18n.t(:"nav.subnav.new_project_for_customer", customer: customer.name) %>" data-toggle="tooltip" data-controller="tooltip">
                 <i class="fa fa-plus"></i>
               </a>
             </div>

--- a/app/views/templates/timesheets/day.html.erb
+++ b/app/views/templates/timesheets/day.html.erb
@@ -50,7 +50,7 @@
             <span class="timesheet-timer-note" ng-bind="timer.note"></span>
           </div>
           <div class="pull-right">
-            <span class="timesheet-timer invoiced" ng-if="timer.invoiced" title="<%= I18n.t(:"labels.timesheet.on_invoice") %>" data-toggle="tooltip">
+            <span class="timesheet-timer invoiced" ng-if="timer.invoiced" title="<%= I18n.t(:"labels.timesheet.on_invoice") %>" data-toggle="tooltip" data-controller="tooltip">
               <span ng-bind="timer.value | toHours"></span>
             </span>
             <span class="timesheet-timer started" ng-if="timer.started">

--- a/app/views/templates/timesheets/week.html.erb
+++ b/app/views/templates/timesheets/week.html.erb
@@ -76,7 +76,7 @@
             <div ng-repeat="timer in task.timers | forDate:date.date">
               <div ng-if="$last">
                 <div class="timesheet-timer invoiced" ng-if="timer.invoiced">
-                  <span title="<%= I18n.t(:"labels.timesheet.on_invoice") %>" data-toggle="tooltip" ng-bind="timer.sumForTask | toHours"></span>
+                  <span title="<%= I18n.t(:"labels.timesheet.on_invoice") %>" data-toggle="tooltip" data-controller="tooltip" ng-bind="timer.sumForTask | toHours"></span>
                 </div>
                 <div class="timesheet-timer started" ng-if="timer.startTimeForTask">
                   <timer start-time="timer.startTimeForTask" max-time-unit="'hour'">{{hours}}:{{mminutes}}</timer>


### PR DESCRIPTION
## Summary

`App.init` ran on every `turbolinks:load` (now `turbo:load` via the shim) and wired up three things globally: Bootstrap 3 tooltips, the Ladda "loading" state on submit buttons, and the moment.js locale. Same pattern as the datepicker/selectize Stimulus ports — move each to a controller scoped per-element so they survive Turbo Frame swaps, and move the moment locale config to a Vite lib that runs once at bundle parse.

## Changes

- **`app/frontend/controllers/tooltip_controller.ts`** — `$(el).tooltip()` on `connect()`, `tooltip("destroy")` on `disconnect()`. Attach via `data-controller=\"tooltip\"` alongside the existing `data-toggle=\"tooltip\"` (kept as a markup convention).
- **`app/frontend/controllers/loading-button_controller.ts`** — adds a click listener that calls Bootstrap 3's `button(\"loading\")` to flip the submit into the spinner state (Ladda's `data-loading-text` does the rest).
- **`app/frontend/lib/moment-locale.ts`** — `moment.updateLocale(I18n.locale, { week: { dow: 1, doy: 4 } })` + `moment.locale(I18n.locale)`. moment itself stays a Sprockets global because chart.coffee + timer.coffee + AngularJS read `window.moment`.
- **`app/frontend/entrypoints/application.ts`** — invokes `configureMomentLocale()` alongside the existing `configureAccounting()` call.
- **`app/assets/javascripts/app/moment.coffee`** — deleted.
- **`app/assets/javascripts/app.coffee`** — `App.init` is now a no-op (kept until `app.coffee` itself ports to Vite).

## Views touched

4 tooltip + 4 btn-loading sites pick up the new data-controllers:

- `data-controller=\"tooltip\"`: `customers/_form`, `projects/_list`, `templates/timesheets/{day,week}` (the two AngularJS-rendered timesheet hints — Stimulus picks them up via its MutationObserver after Angular paints).
- `data-controller=\"loading-button\"`: Devise `sessions/new`, `passwords/{new,edit}`, and the new-account signup button.

## Bundle impact

- Vite `application.js`: 143 → 148 KB (+5 KB for three controllers + moment-locale lib)
- Sprockets `application.js`: trivially smaller (one fewer `App.Moment` class)

## Test plan

- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean
- [x] `bundle exec standardrb` reports no offenses
- [x] `pnpm exec vite build` succeeds
- [x] Manual browser smoke-test:
  - Hover a tooltip target in the project list → Bootstrap tooltip appears
  - Click a Devise sign-in submit (or any `.btn-loading` button) → button flips to \"Laden…\" state
  - Dashboard charts + project show timer panels render dates correctly (moment locale config worked)
  - Open `/projects` → click the archived filter → tooltip on the new-project-for-customer \"+\" buttons still works after the Turbo Frame swap (this is the per-element-scope payoff)

Generated with [Claude Code](https://claude.com/claude-code)