### PR TITLE
feat(customers): wrap customer edit form in a Turbo Frame (Phase 5b)

### DIFF
--- a/app/views/customers/edit.html.erb
+++ b/app/views/customers/edit.html.erb
@@ -29,7 +29,17 @@
       </div>
 
       <div class="col-xs-12 col-lg-10 col-md-9 col-sm-9">
-        <%= render "form" %>
+        <%# Turbo Frame around just the form column — the subnav
+            (tabs) stays put. On submit-success the controller
+            redirects back to `edit_customer_path`; Turbo extracts
+            the matching frame and swaps in place. On validation
+            failure `render "edit"` returns the same template with
+            the same frame id, so the frame swaps with the
+            error-decorated form. `data-turbo-action="advance"`
+            keeps the URL (and its `#tab` hash) in sync. %>
+        <turbo-frame id="customer-form" data-turbo-action="advance">
+          <%= render "form" %>
+        </turbo-frame>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

First Phase 5b PR. Now that datepicker / selectize / tooltip / loading-button init all re-fire on element insertion via Stimulus controllers (#883, #884, #887), the customer edit form's JS-init dependencies survive Turbo Frame swaps and the form can finally move inside a frame.

## Change

A single `<turbo-frame id=\"customer-form\" data-turbo-action=\"advance\">` wraps the form-column rendered by `<%= render \"form\" %>`. The subnav (tab links) stays outside the frame; the tab content + form fields are inside.

## Behavior

- **Submit success**: `CustomersController#update` redirects to `edit_customer_path` with `flash[:success]`. Turbo follows the redirect, finds the same `customer-form` frame id in the response, and swaps the frame contents — chrome (header, delete button, tabs) stays put.
- **Submit failure**: controller `render \"edit\"` returns the same template. Turbo extracts the matching frame; the error-decorated form takes its place.
- **`data-turbo-action=\"advance\"`**: pushes the redirected URL (with its `#<tab>` hash) into history so back-button works and the tab returns to the right pane.

## Inits surviving the swap

- `datepicker_controller` (the `employment_date` + `employment_end_date` fields on the basic tab)
- `tooltip_controller` (the `code[data-target]` paste-hint elements in the email-template tab)
- `selectize_controller` (none in customer form today, but it'd work if one is added)
- `loading-button_controller` (none on this form — uses `shared/forms/_submit`)

## Test plan

- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean
- [x] `bundle exec standardrb` reports no offenses
- [x] `pnpm exec vite build` succeeds (bundle unchanged — no new controllers)
- [ ] Manual browser smoke-test:
  - Edit a customer → change a field on each tab → submit → confirm form re-renders without a full page reload, success toast shows, scroll position preserved
  - Submit with an invalid email → confirm error-decorated form renders, fields kept
  - Switch tabs, edit a date via the datepicker, submit → confirm datepicker re-binds on the swapped frame
  - Hover the paste-hint `<code>` elements in the email template tab → tooltip appears even after a form submit + swap

Generated with [Claude Code](https://claude.com/claude-code)