### PR TITLE
fix(turbo-frames): mark outbound list-item links with data-turbo-frame="_top"

### DIFF
--- a/app/views/invoices/_show.html.erb
+++ b/app/views/invoices/_show.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <div class="col-xs-12 col-md-4 name">
-      <a class="plain" href="<%= invoice_path(invoice) %>">
+      <a class="plain" href="<%= invoice_path(invoice) %>" data-turbo-frame="_top">
         <%= invoice.title %>
       </a>
     </div>
@@ -40,14 +40,14 @@
           <ul class="dropdown-menu dropdown-menu-right" role="menu">
             <% if can? :read, invoice %>
               <li>
-                <a href="<%= invoice_path(invoice) %>">
+                <a href="<%= invoice_path(invoice) %>" data-turbo-frame="_top">
                   <%= I18n.t(:"actions.show") %>
                 </a>
               </li>
             <% end %>
             <% if can? :update, invoice %>
               <li>
-                <a href="<%= edit_invoice_path(invoice) %>">
+                <a href="<%= edit_invoice_path(invoice) %>" data-turbo-frame="_top">
                   <i class="fa fa-edit"></i>
                   <%= I18n.t(:"actions.edit") %>
                 </a>
@@ -56,7 +56,7 @@
             <% if can? :charge, invoice %>
               <% charge_confirm = invoice.send_via_mail? ? I18n.t(:"messages.confirm.charge_mail") : I18n.t(:"messages.confirm.charge") %>
               <li>
-                <a href="<%= charge_invoice_path(invoice) %>" data-method="PUT" data-notyConfirm="<%= charge_confirm %>">
+                <a href="<%= charge_invoice_path(invoice) %>" data-turbo-frame="_top" data-method="PUT" data-notyConfirm="<%= charge_confirm %>">
                   <i class="fa fa-envelope"></i>
                   <%= I18n.t(:"actions.charge") %>
                 </a>
@@ -64,7 +64,7 @@
             <% end %>
             <% if can? :pay, invoice %>
               <li>
-                <%= link_to pay_invoice_path(invoice), data: { turbo_method: :put } do %>
+                <%= link_to pay_invoice_path(invoice), data: { turbo_method: :put, turbo_frame: "_top" } do %>
                   <i class="fa fa-check-square-o"></i>
                   <%= I18n.t(:"actions.pay") %>
                 <% end %>
@@ -73,7 +73,7 @@
             <% if can? :destroy, invoice %>
               <li class="divider"></li>
               <li>
-                <a href="<%= invoice_path(invoice) %>" data-method="DELETE" data-notyConfirm="<%= I18n.t(:"messages.confirm.delete") %>">
+                <a href="<%= invoice_path(invoice) %>" data-turbo-frame="_top" data-method="DELETE" data-notyConfirm="<%= I18n.t(:"messages.confirm.delete") %>">
                   <i class="fa fa-trash"></i>
                   <%= I18n.t(:"actions.delete") %>
                 </a>
@@ -84,30 +84,30 @@
       </div>
 
       <div class="btn-group btn-group-justified visible-xs visible-sm">
-        <a class="btn btn-default" href="<%= invoice_path(invoice) %>">
+        <a class="btn btn-default" href="<%= invoice_path(invoice) %>" data-turbo-frame="_top">
           <%= I18n.t(:"actions.show") %>
         </a>
         <% if can? :update, invoice %>
-          <a class="btn btn-default" href="<%= edit_invoice_path(invoice) %>">
+          <a class="btn btn-default" href="<%= edit_invoice_path(invoice) %>" data-turbo-frame="_top">
             <i class="fa fa-edit"></i>
             <span class="hidden-xs hidden-sm"><%= I18n.t(:"actions.edit") %></span>
           </a>
         <% end %>
         <% if can? :charge, invoice %>
           <% charge_confirm = invoice.send_via_mail? ? I18n.t(:"messages.confirm.charge_mail") : I18n.t(:"messages.confirm.charge") %>
-          <a class="btn btn-default" href="<%= charge_invoice_path(invoice) %>" data-method="PUT" data-notyConfirm="<%= charge_confirm %>">
+          <a class="btn btn-default" href="<%= charge_invoice_path(invoice) %>" data-turbo-frame="_top" data-method="PUT" data-notyConfirm="<%= charge_confirm %>">
             <i class="fa fa-envelope"></i>
             <span class="hidden-xs hidden-sm"><%= I18n.t(:"actions.charge") %></span>
           </a>
         <% end %>
         <% if can? :pay, invoice %>
-          <%= link_to pay_invoice_path(invoice), data: { turbo_method: :put }, class: "btn btn-success" do %>
+          <%= link_to pay_invoice_path(invoice), data: { turbo_method: :put, turbo_frame: "_top" }, class: "btn btn-success" do %>
             <i class="fa fa-check-square-o"></i>
             <span class="hidden-xs hidden-sm"><%= I18n.t(:"actions.pay") %></span>
           <% end %>
         <% end %>
         <% if can? :destroy, invoice %>
-          <a class="btn btn-danger" href="<%= invoice_path(invoice) %>" data-method="DELETE" data-notyConfirm="<%= I18n.t(:"messages.confirm.delete") %>">
+          <a class="btn btn-danger" href="<%= invoice_path(invoice) %>" data-turbo-frame="_top" data-method="DELETE" data-notyConfirm="<%= I18n.t(:"messages.confirm.delete") %>">
             <i class="fa fa-trash"></i>
             <span class="hidden-xs hidden-sm"><%= I18n.t(:"actions.delete") %></span>
           </a>

--- a/app/views/offers/_show.html.erb
+++ b/app/views/offers/_show.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
     <div class="col-xs-12 col-md-4 name">
-      <a class="plain" href="<%= offer_path(offer) %>">
+      <a class="plain" href="<%= offer_path(offer) %>" data-turbo-frame="_top">
         <%= offer.title %>
       </a>
     </div>
@@ -38,14 +38,14 @@
           <ul class="dropdown-menu dropdown-menu-right" role="menu">
             <% if can? :read, offer %>
               <li>
-                <a href="<%= offer_path(offer) %>">
+                <a href="<%= offer_path(offer) %>" data-turbo-frame="_top">
                   <%= I18n.t(:"actions.show") %>
                 </a>
               </li>
             <% end %>
             <% if can? :update, offer %>
               <li>
-                <a href="<%= edit_offer_path(offer) %>">
+                <a href="<%= edit_offer_path(offer) %>" data-turbo-frame="_top">
                   <i class="fa fa-edit"></i>
                   <%= I18n.t(:"actions.edit") %>
                 </a>
@@ -54,7 +54,7 @@
             <% if can? :destroy, offer %>
               <li class="divider"></li>
               <li>
-                <a href="<%= offer_path(offer) %>" data-method="DELETE" data-notyConfirm="<%= I18n.t(:"messages.confirm.delete") %>">
+                <a href="<%= offer_path(offer) %>" data-turbo-frame="_top" data-method="DELETE" data-notyConfirm="<%= I18n.t(:"messages.confirm.delete") %>">
                   <i class="fa fa-trash"></i>
                   <%= I18n.t(:"actions.delete") %>
                 </a>
@@ -65,17 +65,17 @@
       </div>
 
       <div class="btn-group btn-group-justified visible-xs visible-sm">
-        <a class="btn btn-default" href="<%= offer_path(offer) %>">
+        <a class="btn btn-default" href="<%= offer_path(offer) %>" data-turbo-frame="_top">
           <%= I18n.t(:"actions.show") %>
         </a>
         <% if can? :update, offer %>
-          <a class="btn btn-default" href="<%= edit_offer_path(offer) %>">
+          <a class="btn btn-default" href="<%= edit_offer_path(offer) %>" data-turbo-frame="_top">
             <i class="fa fa-edit"></i>
             <span class="hidden-xs hidden-sm"><%= I18n.t(:"actions.edit") %></span>
           </a>
         <% end %>
         <% if can? :destroy, offer %>
-          <a class="btn btn-danger" href="<%= offer_path(offer) %>" data-method="DELETE" data-notyConfirm="<%= I18n.t(:"messages.confirm.delete") %>">
+          <a class="btn btn-danger" href="<%= offer_path(offer) %>" data-turbo-frame="_top" data-method="DELETE" data-notyConfirm="<%= I18n.t(:"messages.confirm.delete") %>">
             <i class="fa fa-trash"></i>
             <span class="hidden-xs hidden-sm"><%= I18n.t(:"actions.delete") %></span>
           </a>

--- a/app/views/projects/_list.html.erb
+++ b/app/views/projects/_list.html.erb
@@ -4,7 +4,7 @@
       <div class="panel-title">
         <div class="row">
           <div class="col-xs-8 col-md-4 name">
-            <a href="<%= edit_customer_path(customer) %>">
+            <a href="<%= edit_customer_path(customer) %>" data-turbo-frame="_top">
               <strong>
                 <%= customer.name %>
               </strong>
@@ -22,7 +22,7 @@
           </div>
           <div class="col-xs-4 col-md-2">
             <div class="panel-list-action pull-right">
-              <a class="btn btn-default" href="<%= new_project_path(customer_id: customer) %>" title="<%= I18n.t(:"nav.subnav.new_project_for_customer", customer: customer.name) %>" data-toggle="tooltip" data-controller="tooltip">
+              <a class="btn btn-default" href="<%= new_project_path(customer_id: customer) %>" title="<%= I18n.t(:"nav.subnav.new_project_for_customer", customer: customer.name) %>" data-toggle="tooltip" data-controller="tooltip" data-turbo-frame="_top">
                 <i class="fa fa-plus"></i>
               </a>
             </div>

--- a/app/views/projects/_show.html.erb
+++ b/app/views/projects/_show.html.erb
@@ -1,7 +1,7 @@
 <div class="list-group-item">
   <div class="row">
     <div class="col-xs-12 col-md-4 project-name">
-      <a class="plain" href="<%= project_path(project) %>">
+      <a class="plain" href="<%= project_path(project) %>" data-turbo-frame="_top">
         <b><%= project.name %></b>
       </a>
     </div>
@@ -31,25 +31,25 @@
             </button>
             <ul class="dropdown-menu dropdown-menu-right" role="menu">
               <li>
-                <a href="<%= project_path(project) %>">
+                <a href="<%= project_path(project) %>" data-turbo-frame="_top">
                   <%= I18n.t(:"actions.show") %>
                 </a>
               </li>
               <li>
-                <a href="<%= new_invoice_path(project_id: project) %>">
+                <a href="<%= new_invoice_path(project_id: project) %>" data-turbo-frame="_top">
                   <i class="fa fa-plus"></i>
                   <%= I18n.t(:"actions.add_invoice") %>
                 </a>
               </li>
               <li>
-                <a href="<%= edit_project_path(project) %>">
+                <a href="<%= edit_project_path(project) %>" data-turbo-frame="_top">
                   <i class="fa fa-edit"></i>
                   <%= I18n.t(:"actions.edit") %>
                 </a>
               </li>
               <li class="divider"></li>
               <li>
-                <a href="<%= archive_v1_project_url(project) %>" data-redirect="<%= projects_path %>" data-method="PUT" data-notyConfirm="<%= I18n.t(:"messages.confirm.project.archive") %>">
+                <a href="<%= archive_v1_project_url(project) %>" data-turbo-frame="_top" data-redirect="<%= projects_path %>" data-method="PUT" data-notyConfirm="<%= I18n.t(:"messages.confirm.project.archive") %>">
                   <i class="fa fa-archive"></i>
                   <%= I18n.t(:"actions.archive") %>
                 </a>
@@ -58,28 +58,28 @@
           </div>
         </div>
         <div class="btn-group btn-group-justified visible-xs visible-sm">
-          <a class="btn btn-default" href="<%= project_path(project) %>">
+          <a class="btn btn-default" href="<%= project_path(project) %>" data-turbo-frame="_top">
             <%= I18n.t(:"actions.show") %>
           </a>
-          <a class="btn btn-default" href="<%= new_invoice_path(project_id: project) %>" title="<%= I18n.t(:"actions.add_invoice") %>">
+          <a class="btn btn-default" href="<%= new_invoice_path(project_id: project) %>" data-turbo-frame="_top" title="<%= I18n.t(:"actions.add_invoice") %>">
             <i class="fa fa-plus"></i>
             <span class="hidden-xs hidden-sm"><%= I18n.t(:"actions.add_invoice") %></span>
           </a>
-          <a class="btn btn-default" href="<%= edit_project_path(project) %>" title="<%= I18n.t(:"actions.edit") %>">
+          <a class="btn btn-default" href="<%= edit_project_path(project) %>" data-turbo-frame="_top" title="<%= I18n.t(:"actions.edit") %>">
             <i class="fa fa-edit"></i>
             <span class="hidden-xs hidden-sm"><%= I18n.t(:"actions.edit") %></span>
           </a>
-          <a class="btn btn-default" href="<%= archive_v1_project_url(project) %>" data-redirect="<%= projects_path %>" data-method="PUT" data-notyConfirm="<%= I18n.t(:"messages.confirm.project.archive") %>" title="<%= I18n.t(:"actions.archive") %>">
+          <a class="btn btn-default" href="<%= archive_v1_project_url(project) %>" data-turbo-frame="_top" data-redirect="<%= projects_path %>" data-method="PUT" data-notyConfirm="<%= I18n.t(:"messages.confirm.project.archive") %>" title="<%= I18n.t(:"actions.archive") %>">
             <i class="fa fa-archive"></i>
             <span class="hidden-xs hidden-sm"><%= I18n.t(:"actions.archive") %></span>
           </a>
         </div>
       <% else %>
         <div class="pull-right hidden-xs hidden-sm">
-          <%= link_to I18n.t(:"actions.unarchive"), unarchive_project_path(project), class: "btn btn-default", data: { turbo_method: :put } %>
+          <%= link_to I18n.t(:"actions.unarchive"), unarchive_project_path(project), class: "btn btn-default", data: { turbo_method: :put, turbo_frame: "_top" } %>
         </div>
         <div class="btn-group btn-group-sm btn-group-justified visible-xs visible.sm">
-          <%= link_to I18n.t(:"actions.unarchive"), unarchive_project_path(project), class: "btn btn-default", data: { turbo_method: :put } %>
+          <%= link_to I18n.t(:"actions.unarchive"), unarchive_project_path(project), class: "btn btn-default", data: { turbo_method: :put, turbo_frame: "_top" } %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## Summary

Bug report from the field: clicking a customer name on `/projects` landed on `/projects` with the customer area blank and **"Content missing"** in place of the customer edit page. Same bug affects every list-item link in the Phase 5 index frames.

## Root cause

The Phase 5 batches (#873, #874, #875) wrapped projects/offers/invoices index lists in a `<turbo-frame>` so filter + pagination + sort clicks swap just the list. But every other link _inside_ those frames inherited the frame's intercepting behavior: Turbo issued the request and looked for the same frame id in the response. The response (e.g. customer edit) doesn't have that frame → Turbo renders the "Content missing" placeholder.

## Fix

Add `data-turbo-frame=\"_top\"` to outbound links inside the list-item partials so Turbo navigates the whole page instead of trying to swap the frame. Filter / pagination / sort links remain unmarked — they SHOULD stay in-frame, that's the whole point.

Touched partials:
- `projects/_list.html.erb` — customer name link, customer "+" button
- `projects/_show.html.erb` — 10 link sites (dropdown + responsive button group + unarchive `link_to`)
- `offers/_show.html.erb` — 7 link sites
- `invoices/_show.html.erb` — 11 link sites

The noty-confirm flow (`data-method=\"DELETE/PUT\"` + `data-notyConfirm`) is unaffected — its jQuery handler returns `false` (`preventDefault` + `stopPropagation`) so Turbo never sees the click. Marking those links anyway is belt-and-suspenders for the edge case where the noty handler isn't bound yet.

## Test plan

- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean
- [x] `bundle exec standardrb` reports no offenses
- [ ] **Manual browser smoke-test (the actual signal):**
  - Click a customer name on `/projects` → land on `/customers/:id/edit` (full nav)
  - Click each dropdown action on a project / offer / invoice → land on the right destination, no \"Content missing\"
  - Filter / pagination / sort on each index → still swap in-frame (i.e. the URL updates but the chrome stays put)
  - On `/projects?state=archived` → click unarchive → confirm it lands on `/projects` correctly

Generated with [Claude Code](https://claude.com/claude-code)