### PR TITLE
feat(frontend): Vue 3 islands foundation (Phase 6a)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,14 @@ Done (Phases 1–4 + Phase 5 in progress):
 - Phase 4 — Turbo Drive + Stimulus baseline; Turbolinks gone
   (#871, #872)
 - Phase 5 — Turbo Frames on CRUD index pages
-  (projects #873, offers #874, invoices #875)
-- Phase 8 — Cypress 12 → Playwright; cleared the last 11 dev-only
-  npm vulns
+  (projects #873, offers #874, invoices #875) + customer edit
+  form (#888)
+- Phase 6a — Vue 3 islands foundation: `vue`, `@vitejs/plugin-vue`,
+  `app/frontend/islands/<name>/`, the `mountIslands(registry)`
+  helper, and a `hello` smoke-test SFC. Actual timesheet +
+  timers-calendar ports come next.
+- Phase 8 — Cypress 12 → Playwright + cypress-on-rails bridge;
+  cleared the last 11 dev-only npm vulns
 
 Still legacy (to be removed in later phases):
 

--- a/app/frontend/entrypoints/application.ts
+++ b/app/frontend/entrypoints/application.ts
@@ -18,6 +18,8 @@ import { Application } from "@hotwired/stimulus"
 
 import { configureAccounting, installAccountingGlobal } from "../lib/accounting"
 import { configureMomentLocale } from "../lib/moment-locale"
+import { mountIslands } from "../lib/mount-islands"
+import Hello from "../islands/hello/Hello.vue"
 
 // PDF.js v4+ ships ESM-only. Lazy-loaded so the 1.5 MB pdfjs core +
 // worker don't ship on pages that never render a PDF (most of them).
@@ -89,6 +91,19 @@ if (i18nGlobal) {
 // chart.coffee + AngularJS as a global). Just configure the locale
 // + ISO week here, replacing what `App.Moment.init` used to do.
 configureMomentLocale()
+
+// Phase 6 — Vue 3 islands. The real timesheet + timers-calendar
+// ports live under `app/frontend/islands/<name>/`; for now we just
+// ship the foundation: Vue is installed, Vite knows how to compile
+// `.vue` SFCs, and the mounter walks `[data-island]` elements on
+// every Turbo navigation. The placeholder `hello` island acts as
+// a smoke test — drop `<div data-island="hello"></div>` into any
+// view and the SFC renders.
+const islandRegistry = {
+  hello: Hello,
+}
+mountIslands(islandRegistry)
+document.addEventListener("turbo:load", () => mountIslands(islandRegistry))
 
 const application = Application.start()
 

--- a/app/frontend/islands/hello/Hello.vue
+++ b/app/frontend/islands/hello/Hello.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+// Smoke-test Vue island. Confirms `.vue` SFC compilation + the
+// mount machinery in `app/frontend/lib/mount-islands.ts` works
+// end-to-end. Drop a `<div data-island="hello"></div>` anywhere
+// in a view and the heading + counter button render.
+//
+// Real islands replace the AngularJS apps in Phase 6 — see
+// docs/frontend-migration-plan.md.
+import { ref } from "vue"
+
+const props = defineProps<{ name?: string }>()
+const count = ref(0)
+</script>
+
+<template>
+  <div class="inline-flex items-center gap-3 rounded bg-emerald-50 border border-emerald-200 px-3 py-2 text-emerald-900">
+    <span class="font-medium">Hello, {{ props.name ?? "Vue" }}</span>
+    <button
+      type="button"
+      class="rounded bg-emerald-600 px-2 py-0.5 text-sm font-medium text-white hover:bg-emerald-500"
+      @click="count++"
+    >
+      clicked {{ count }}×
+    </button>
+  </div>
+</template>

--- a/app/frontend/lib/mount-islands.ts
+++ b/app/frontend/lib/mount-islands.ts
@@ -1,0 +1,49 @@
+import { createApp, type Component } from "vue"
+
+// Generic Vue island mounter. Pages opt in by rendering a
+// `<div data-island="<name>" data-island-props='{"…":"…"}'></div>`
+// element. This module looks up the matching component in the
+// passed registry and mounts a Vue app at the element.
+//
+// Why an islands pattern rather than one big SPA: the rest of the
+// reckoning UI is server-rendered ERB + Turbo Frames. We only
+// reach for Vue on the two interaction-heavy screens (timesheet,
+// timers calendar) that justify its complexity. The islands
+// architecture lets the two coexist without colliding.
+//
+// `data-island-props` is parsed as JSON. Missing or invalid JSON
+// is ignored — the component runs with whatever defaults it has.
+
+type IslandRegistry = Record<string, Component>
+
+export function mountIslands(registry: IslandRegistry): void {
+  const mounts = document.querySelectorAll<HTMLElement>("[data-island]")
+  for (const mount of mounts) {
+    const name = mount.dataset.island
+    if (!name) continue
+    const component = registry[name]
+    if (!component) {
+      // Unknown island name — fail loud in dev so a typo is
+      // caught early; silent in prod so a stale view doesn't
+      // crash the page.
+      if (import.meta.env.DEV) {
+        console.error(`[islands] No registered component for data-island="${name}"`)
+      }
+      continue
+    }
+
+    let props: Record<string, unknown> = {}
+    const propsAttr = mount.dataset.islandProps
+    if (propsAttr) {
+      try {
+        props = JSON.parse(propsAttr)
+      } catch (e) {
+        if (import.meta.env.DEV) {
+          console.error(`[islands] data-island-props for "${name}" is not valid JSON:`, e)
+        }
+      }
+    }
+
+    createApp(component, props).mount(mount)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,15 +16,18 @@
     "@hotwired/turbo": "^8.0.23",
     "accounting": "^0.4.1",
     "pdfjs-dist": "4.10.38",
-    "puppeteer": "^23.0.0"
+    "puppeteer": "^23.0.0",
+    "vue": "^3.5.35"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.3.0",
+    "@vitejs/plugin-vue": "^6.0.7",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.2.2",
     "vite": "^7.3.5",
-    "vite-plugin-ruby": "^5.2.2"
+    "vite-plugin-ruby": "^5.2.2",
+    "vue-tsc": "^3.3.4"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       puppeteer:
         specifier: ^23.0.0
         version: 23.11.1(typescript@5.2.2)
+      vue:
+        specifier: ^3.5.35
+        version: 3.5.35(typescript@5.2.2)
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -30,6 +33,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.7
+        version: 6.0.7(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))(vue@3.5.35(typescript@5.2.2))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -42,6 +48,9 @@ importers:
       vite-plugin-ruby:
         specifier: ^5.2.2
         version: 5.2.2(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))
+      vue-tsc:
+        specifier: ^3.3.4
+        version: 3.3.4(typescript@5.2.2)
 
 packages:
 
@@ -49,8 +58,21 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -312,6 +334,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rollup/rollup-android-arm-eabi@4.61.1':
     resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
     cpu: [arm]
@@ -539,12 +564,63 @@ packages:
   '@types/yauzl@2.10.0':
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
 
+  '@vitejs/plugin-vue@6.0.7':
+    resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vue/compiler-core@3.5.35':
+    resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
+
+  '@vue/compiler-dom@3.5.35':
+    resolution: {integrity: sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==}
+
+  '@vue/compiler-sfc@3.5.35':
+    resolution: {integrity: sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==}
+
+  '@vue/compiler-ssr@3.5.35':
+    resolution: {integrity: sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==}
+
+  '@vue/language-core@3.3.4':
+    resolution: {integrity: sha512-IuHqQ5zGGOE7CXP72VX6A42IVeIzYv4WAhO6arej11TRNqtdZfGyH8Yr2FOCaDX0dSQG+JwULLoFHGY1igYVjQ==}
+
+  '@vue/reactivity@3.5.35':
+    resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
+
+  '@vue/runtime-core@3.5.35':
+    resolution: {integrity: sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==}
+
+  '@vue/runtime-dom@3.5.35':
+    resolution: {integrity: sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==}
+
+  '@vue/server-renderer@3.5.35':
+    resolution: {integrity: sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==}
+    peerDependencies:
+      vue: 3.5.35
+
+  '@vue/shared@3.5.35':
+    resolution: {integrity: sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==}
+
   accounting@0.4.1:
     resolution: {integrity: sha512-RU6KY9Y5wllyaCNBo1W11ZOTnTHMMgOZkIwdOOs6W5ibMTp72i4xIbEA48djxVGqMNTUNbvrP/1nWg5Af5m2gQ==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -652,6 +728,9 @@ packages:
       typescript:
         optional: true
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
@@ -686,6 +765,10 @@ packages:
     resolution: {integrity: sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==}
     engines: {node: '>=10.13.0'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -715,6 +798,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -894,6 +980,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -925,6 +1014,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   pdfjs-dist@4.10.38:
     resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
@@ -1112,6 +1204,23 @@ packages:
       yaml:
         optional: true
 
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-tsc@3.3.4:
+    resolution: {integrity: sha512-XA/JqmQwS2GZmfgpjOEGdrKwaTSEuPwxpHa7/t6f4yiGrJb3gVHTPb9wBfByMNZwQ+xDXs41b8gaS2DKsOozUw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  vue@3.5.35:
+    resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -1157,7 +1266,18 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -1328,6 +1448,8 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rollup/rollup-android-arm-eabi@4.61.1':
     optional: true
 
@@ -1483,9 +1605,93 @@ snapshots:
       '@types/node': 18.15.11
     optional: true
 
+  '@vitejs/plugin-vue@6.0.7(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))(vue@3.5.35(typescript@5.2.2))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
+      vue: 3.5.35(typescript@5.2.2)
+
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.35
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.35':
+    dependencies:
+      '@vue/compiler-core': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/compiler-sfc@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.35
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.15
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.35':
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/language-core@3.3.4':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
+
+  '@vue/reactivity@3.5.35':
+    dependencies:
+      '@vue/shared': 3.5.35
+
+  '@vue/runtime-core@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/runtime-dom@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/runtime-core': 3.5.35
+      '@vue/shared': 3.5.35
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@5.2.2))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      vue: 3.5.35(typescript@5.2.2)
+
+  '@vue/shared@3.5.35': {}
+
   accounting@0.4.1: {}
 
   agent-base@7.1.4: {}
+
+  alien-signals@3.2.1: {}
 
   ansi-regex@5.0.1: {}
 
@@ -1573,6 +1779,8 @@ snapshots:
     optionalDependencies:
       typescript: 5.2.2
 
+  csstype@3.2.3: {}
+
   data-uri-to-buffer@6.0.2: {}
 
   debug@4.4.3:
@@ -1599,6 +1807,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -1648,6 +1858,8 @@ snapshots:
   esprima@4.0.1: {}
 
   estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
 
   esutils@2.0.3: {}
 
@@ -1797,6 +2009,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   nanoid@3.3.12: {}
 
   netmask@2.1.1: {}
@@ -1835,6 +2049,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  path-browserify@1.0.1: {}
 
   pdfjs-dist@4.10.38:
     optionalDependencies:
@@ -2067,6 +2283,24 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
+
+  vscode-uri@3.1.0: {}
+
+  vue-tsc@3.3.4(typescript@5.2.2):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.4
+      typescript: 5.2.2
+
+  vue@3.5.35(typescript@5.2.2):
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-sfc': 3.5.35
+      '@vue/runtime-dom': 3.5.35
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@5.2.2))
+      '@vue/shared': 3.5.35
+    optionalDependencies:
+      typescript: 5.2.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
       "@/*": ["./app/frontend/*"],
       "~/*": ["*"]
     },
-    "types": ["cypress", "node", "vitest/globals", "vite/client"]
+    "types": ["node", "vite/client"]
   },
   "include": [
     "@types/*",
@@ -25,7 +25,6 @@
     "app/frontend/**/*.tsx",
     "app/frontend/**/*.vue",
     "app/frontend/**/*.d.ts",
-    "test/javascript/**/*.ts",
-    "cypress/**/*.ts"
+    "test/e2e/**/*.ts"
   ]
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,10 +1,8 @@
-import { defineConfig } from 'vite'
-import RubyPlugin from 'vite-plugin-ruby'
-import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from "vite"
+import RubyPlugin from "vite-plugin-ruby"
+import tailwindcss from "@tailwindcss/vite"
+import vue from "@vitejs/plugin-vue"
 
 export default defineConfig({
-  plugins: [
-    RubyPlugin(),
-    tailwindcss(),
-  ],
+  plugins: [RubyPlugin(), tailwindcss(), vue()],
 })


### PR DESCRIPTION
## Summary

Ships the toolchain + mounting pattern for the Vue 3 islands that Phase 6 will use to replace the two AngularJS apps (timesheet, timers calendar). No real island ports yet — that's Phase 6b/6c onwards. Same shape as the Phase 4a Hotwire-dormant PR: install the tools, prove the build round-trip, leave the actual feature work for follow-ups.

## Toolchain

- `pnpm add vue@^3.5` (production dep)
- `pnpm add -D @vitejs/plugin-vue vue-tsc`
- `vite.config.mts` registers `@vitejs/plugin-vue` so `.vue` SFCs compile through Vite.
- `tsconfig.json` already included `app/frontend/**/*.vue`; tidied `types` (dropped stale `cypress` + unused `vitest/globals`) and swapped `cypress/**` for `test/e2e/**` in `include`.

## Mounting pattern

- **`app/frontend/lib/mount-islands.ts`** — generic mounter. Walks `[data-island]` elements, looks the name up in a registry, parses optional `data-island-props` JSON, and `createApp(component, props).mount(el)`.
- **`app/frontend/entrypoints/application.ts`** keeps a registry of registered islands and runs `mountIslands(registry)` on initial load + every `turbo:load`. Frame swaps that contain `[data-island]` elements get them mounted on the next nav.

## Smoke-test island

- **`app/frontend/islands/hello/Hello.vue`** — tiny SFC with a Tailwind-styled counter. Drop `<div data-island=\"hello\"></div>` in any view and it renders \"Hello, Vue / clicked N×\". Confirms the round trip works.

## Bundle impact

- Vite `application.js`: 149 KB → 211 KB (+62 KB for Vue 3 runtime + the smoke-test SFC). Expected for an islands-style Vue setup.
- `pnpm audit` still reports zero vulnerabilities (prod + dev).

## What's NOT in this PR

- The actual timesheet + timers-calendar replacements — multi-week pieces. Each will land as its own PR series behind a `NEW_*` env flag, per the migration plan.
- No `app/views/` mount yet — the smoke test was confirmed by manually adding `data-island=\"hello\"` in a dev browser.

## Test plan

- [x] `bundle exec ruby -e 'require \"./config/application\"'` boots clean
- [x] `bundle exec standardrb` reports no offenses
- [x] `pnpm exec vite build` succeeds (Vue + SFC + worker chunks)
- [x] `pnpm audit` reports zero vulnerabilities
- [x] Local: drop `<div data-island=\"hello\"></div>` into a view → SFC renders, counter increments
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)