### PR TITLE
fix(boot): require 'ostruct' explicitly

### DIFF
--- a/config/initializers/load_stdlib.rb
+++ b/config/initializers/load_stdlib.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Explicit stdlib loads.
+#
+# Ruby 3.4+ stopped auto-loading parts of stdlib that were previously
+# pulled in as a transitive side-effect of various gems. The list of
+# gems that happened to `require "ostruct"` has shrunk over time —
+# whenever a Gemfile bump drops the last such gem from the dep tree,
+# any view / helper using `OpenStruct` 500s with
+# `NameError: uninitialized constant ::OpenStruct`.
+#
+# `app/views/shared/tables/_filter.html.erb` uses `OpenStruct.new`,
+# and an indeterminate set of other call sites may too. Pulling the
+# require in here makes the app immune to which gems happen to load
+# it transitively.
+require "ostruct"


### PR DESCRIPTION
## Summary

`app/views/shared/tables/_filter.html.erb:35` uses `OpenStruct.new` but no app code requires `ostruct` explicitly. The view only works on `main` today because *some* gem in the dependency tree happens to `require "ostruct"` as a side-effect. Whenever a Dependabot bump drops the last such gem, every page rendering that partial 500s with:

```
ActionView::Template::Error (uninitialized constant ::OpenStruct):
```

## Diagnosis

Bisected the `InvoicesControllerTest#test_0001 User can view the invoice list` failure on #894. Applied that PR's full `Gemfile.lock` to current `main` → 500. Reverted, applied each likely-culprit gem individually (cancancan, mobility, aasm) → all green. Applied the full lockfile → 500 reproduced; the test log surfaced the `OpenStruct` `NameError`. Which gem specifically drops the transitive require doesn't matter — depending on one is the actual bug.

## Fix

`config/initializers/load_stdlib.rb` → `require "ostruct"`. One line, zero behavior change for normal app traffic, immune to future bumps.

## Test plan

- [x] `bundle exec rails test test/controllers/invoices_controller_test.rb` — 14 runs, 0 failures
- [x] With #894's full `Gemfile.lock` applied locally + this fix — 14 runs, 0 failures (without the fix → 1 failure on `test_0001`)
- [x] On `main` + this fix (no Gemfile changes) — 14 runs, 0 failures

## Unblocks

#894 — once this lands, the only remaining issue on that Dependabot PR is the stale `connection_pool < 3` constraint conflict with merged #899 (`< 4`, on `3.0.2`). That's a regenerate-the-PR issue, not a real test failure.

🤖